### PR TITLE
[factorization] Correct typos in docstrings

### DIFF
--- a/applications/createxdmf/main.cpp
+++ b/applications/createxdmf/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
     ierr = PetscFinalize(); CHKERRQ(ierr);
     
     return 0;
-}
+} // main
 
 
 PetscErrorCode writeSingleXDMF(
@@ -236,4 +236,4 @@ PetscErrorCode writeSingleXDMF(
     ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // writeSingleXDMF

--- a/applications/decoupledibpm/decoupledibpm.cpp
+++ b/applications/decoupledibpm/decoupledibpm.cpp
@@ -39,7 +39,7 @@ DecoupledIBPMSolver::~DecoupledIBPMSolver()
     ierr = MatDestroy(&E); CHKERRV(ierr);
     ierr = MatDestroy(&EBNH); CHKERRV(ierr);
     ierr = MatDestroy(&BNH); CHKERRV(ierr);
-}
+} // ~DecoupledIBPMSolver
 
 
 // destroy
@@ -64,7 +64,7 @@ PetscErrorCode DecoupledIBPMSolver::destroy()
     ierr = NavierStokesSolver::destroy(); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // finalize
+} // destroy
 
 
 PetscErrorCode DecoupledIBPMSolver::initialize(
@@ -146,7 +146,7 @@ PetscErrorCode DecoupledIBPMSolver::createExtraOperators()
     // That is, (H*R^{-1}*f). While H = R*Delta, This means the real scattering
     // operator used in momentum equation is just a Delta operator. So we just
     // let H be the Delta operator. One thing to remember is that this is based
-    // on the assumption that the size of Lagragian element is equal to the size
+    // on the assumption that the size of Lagrangian element is equal to the size
     // of the Eulerian grid near by.
 
     // create operator BN
@@ -170,7 +170,7 @@ PetscErrorCode DecoupledIBPMSolver::createExtraOperators()
     ierr = MatDestroy(&BN); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // assembleOperators
+} // createExtraOperators
 
 
 // create extra vectors for decoupled method
@@ -187,7 +187,7 @@ PetscErrorCode DecoupledIBPMSolver::createExtraVectors()
     ierr = VecDuplicate(f, &df); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // createExtraVectors
 
 
 // advance one time-step
@@ -205,7 +205,7 @@ PetscErrorCode DecoupledIBPMSolver::advance()
     ierr = assembleRHSForces(); CHKERRQ(ierr);
     ierr = solveForces(); CHKERRQ(ierr);
     
-    // prepare poisson system and solve it
+    // prepare Poisson system and solve it
     ierr = assembleRHSPoisson(); CHKERRQ(ierr);
     ierr = solvePoisson(); CHKERRQ(ierr);
     
@@ -216,7 +216,7 @@ PetscErrorCode DecoupledIBPMSolver::advance()
     ierr = bc->updateGhostValues(solution); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // solve
+} // advance
 
 
 // prepare right-hand-side for velocity system
@@ -254,8 +254,8 @@ PetscErrorCode DecoupledIBPMSolver::assembleRHSForces()
     ierr = MatMult(E, solution->UGlobal, Eu); CHKERRQ(ierr);
     ierr = VecScale(Eu, -1.0); CHKERRQ(ierr);
     
-    // zerolize df, because the force increment should not have anything to do
-    // with that of the previous teim-step
+    // set Vec df with zeros, because the force increment should not have anything to do
+    // with that of the previous time-step
     ierr = VecSet(df, 0.0); CHKERRQ(ierr);
 
     ierr = PetscLogStagePop(); CHKERRQ(ierr);
@@ -358,7 +358,7 @@ PetscErrorCode DecoupledIBPMSolver::writeRestartData(const std::string &filePath
     ierr = PetscLogStagePop(); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // writeRestartData
 
 
 // read data necessary for restarting
@@ -380,7 +380,7 @@ PetscErrorCode DecoupledIBPMSolver::readRestartData(const std::string &filePath)
     // go to the root node first. Not necessary. Just in case.
     ierr = PetscViewerHDF5PushGroup(viewer, "/"); CHKERRQ(ierr);
 
-    // save Lagragian forces
+    // save Lagrangian forces
     ierr = PetscObjectSetName((PetscObject) f, "force"); CHKERRQ(ierr);
     ierr = VecLoad(f, viewer); CHKERRQ(ierr);
     
@@ -388,7 +388,7 @@ PetscErrorCode DecoupledIBPMSolver::readRestartData(const std::string &filePath)
     ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // readRestartData
 
 
 // write # of iterations and residuals of linear solvers

--- a/applications/decoupledibpm/decoupledibpm.h
+++ b/applications/decoupledibpm/decoupledibpm.h
@@ -16,7 +16,7 @@
 
 /**
  * \class DecoupledIBPMSolver
- * \brief Immersed-boundary method proposed by Li et. al. (2007).
+ * \brief Immersed-boundary method proposed by Li et. al. (2016).
  * \see decoupledibpm, NavierStokesSolver
  * \ingroup decoupledibpm
  */
@@ -66,7 +66,7 @@ public:
      * \brief Write the extra data that are required for restarting sessions.
      * 
      * If file already exists, only extra necessary data will
-     * be writen in. Otherwise, solutions and extra data will all be writen in.
+     * be written in. Otherwise, solutions and extra data will all be written in.
      *
      * \param filePath [in] path of the file to save (without extension)
      */
@@ -123,7 +123,7 @@ protected:
     /** \brief Right-hand-side of force system. */
     Vec Eu;
     
-    /** \brief Solution of Lagragian force at time-step n. */
+    /** \brief Solution of Lagrangian force at time-step n. */
     Vec f;
     
     /** \brief Increment of force from time-step n to n+1. */

--- a/applications/decoupledibpm/main.cpp
+++ b/applications/decoupledibpm/main.cpp
@@ -25,13 +25,13 @@
  * \brief Implementation of parallel decoupled IBPM solver (Li et. al. 2016).
  * 
  * This is an example of using PetIBM to build a parallel incompressible flow 
- * solver with the immersed-boundary method prposed by Li et. al. 2016. We name
+ * solver with the immersed-boundary method proposed by Li et. al. 2016. We name
  * this solver \a decoupled \a IBPM".
  * 
  * If readers are interested in using this solver instead of coding,
  * please refer to 
  * \ref md_runpetibm "Running PetIBM",
- * \ref md_examples2d "2D Exmaples", and
+ * \ref md_examples2d "2D Examples", and
  * \ref md_examples3d "3D Examples".
  * 
  * \b Reference: \n

--- a/applications/navierstokes/main.cpp
+++ b/applications/navierstokes/main.cpp
@@ -31,14 +31,14 @@
  * \brief Implementation of parallel Navier-Stokes solver
  * 
  * This is an example of using PetIBM to build a parallel incompressible flow 
- * solver. The scheme used can be found in Perot 1993 and Chang et. al. 2002.
+ * solver. The scheme used can be found in Perot (1993) and Chang et. al. (2002).
  * This example is a good starting point to learn how to use PetIBM to build
  * an immersed-boundary solver under Perot's framework.
  * 
  * If readers are interested in using the Navier-Stokes solver instead of coding,
  * please refer to 
  * \ref md_runpetibm "Running PetIBM",
- * \ref md_examples2d "2D Exmaples", and
+ * \ref md_examples2d "2D Examples", and
  * \ref md_examples3d "3D Examples".
  * 
  * \b Reference: \n

--- a/applications/navierstokes/navierstokes.cpp
+++ b/applications/navierstokes/navierstokes.cpp
@@ -54,7 +54,7 @@ NavierStokesSolver::~NavierStokesSolver()
     for(auto &it: asciiViewers) {
         ierr = PetscViewerDestroy(&it.second); CHKERRV(ierr);
     }
-}
+} // ~NavierStokesSolver
 
 
 PetscErrorCode NavierStokesSolver::destroy()
@@ -102,7 +102,7 @@ PetscErrorCode NavierStokesSolver::destroy()
     asciiViewers.clear();
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 
 PetscErrorCode NavierStokesSolver::initialize(const petibm::type::Mesh &inMesh,
@@ -147,7 +147,7 @@ PetscErrorCode NavierStokesSolver::initialize(const petibm::type::Mesh &inMesh,
     // create operators (PETSc Mats)
     ierr = createOperators(); CHKERRQ(ierr);
 
-    // creater PETSc Vecs
+    // create PETSc Vecs
     ierr = createVectors(); CHKERRQ(ierr);
 
     // set coefficient matrix to linear solvers
@@ -206,7 +206,7 @@ PetscErrorCode NavierStokesSolver::createOperators()
     ierr = MatDestroy(&BN); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // assembleOperators
+} // createOperators
 
 
 PetscErrorCode NavierStokesSolver::createVectors()
@@ -231,7 +231,7 @@ PetscErrorCode NavierStokesSolver::createVectors()
     }
 
     PetscFunctionReturn(0);
-}
+} // createVectors
 
 
 PetscErrorCode NavierStokesSolver::setNullSpace()
@@ -269,7 +269,7 @@ PetscErrorCode NavierStokesSolver::setNullSpace()
     }
     
     PetscFunctionReturn(0);
-}
+} // setNullSpace
 
 
 // advance the flow solver for one time-step
@@ -283,7 +283,7 @@ PetscErrorCode NavierStokesSolver::advance()
     ierr = assembleRHSVelocity(); CHKERRQ(ierr);
     ierr = solveVelocity(); CHKERRQ(ierr);
 
-    // prepare poisson system and solve it
+    // prepare Poisson system and solve it
     ierr = assembleRHSPoisson(); CHKERRQ(ierr);
     ierr = solvePoisson(); CHKERRQ(ierr);
 
@@ -294,7 +294,7 @@ PetscErrorCode NavierStokesSolver::advance()
     ierr = bc->updateGhostValues(solution); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // solve
+} // advance
 
 
 // prepare right-hand-side vector for velocity solver
@@ -422,7 +422,7 @@ PetscErrorCode NavierStokesSolver::assembleRHSPoisson()
 } // assembleRHSPoisson
 
 
-// solve poisson system
+// solve Poisson system
 PetscErrorCode NavierStokesSolver::solvePoisson()
 {
     PetscErrorCode ierr;
@@ -535,7 +535,7 @@ PetscErrorCode NavierStokesSolver::writeRestartData(const std::string &filePath)
     ierr = PetscLogStagePop(); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // writeRestartData
 
 
 // read data necessary for restarting
@@ -595,7 +595,7 @@ PetscErrorCode NavierStokesSolver::readRestartData(const std::string &filePath)
     ierr = bc->setGhostICs(solution); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // readRestartData
 
 
 PetscErrorCode NavierStokesSolver::initializeASCIIFiles(
@@ -611,7 +611,7 @@ PetscErrorCode NavierStokesSolver::initializeASCIIFiles(
     ierr = PetscViewerFileSetName(asciiViewers[filePath], filePath.c_str()); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // initializeASCIIFiles
 
 
 // write numbers of iterations and residuals of linear solvers to a file

--- a/applications/navierstokes/navierstokes.h
+++ b/applications/navierstokes/navierstokes.h
@@ -82,7 +82,7 @@ public:
      * \brief Write the extra data that are required for restarting sessions.
      * 
      * If the file already has solutions in it, only extra necessary data will
-     * be writen in. Otherwise, solutions and extra data will all be writen in.
+     * be written in. Otherwise, solutions and extra data will all be written in.
      *
      * \param filePath [in] path of the file to save (without the extension)
      */
@@ -96,9 +96,9 @@ public:
     PetscErrorCode readRestartData(const std::string &filePath);
 
     /**
-     * \brief Initialize vewers for ASCII files, such as iteration log.
+     * \brief Initialize viewers for ASCII files, such as iteration log.
      *
-     * \param filePath [in] a tring indicating the path to the file.
+     * \param filePath [in] a string indicating the path to the file.
      * \param mode [in] either FILE_MODE_WRITE (default) or FILE_MODE_APPEND.
      *
      * \return PetscErrorCode.
@@ -204,7 +204,7 @@ protected:
     
 
     
-    /** \brief A bool indicating if we'll pin a reference pressure point. */
+    /** \brief A Bool indicating if we'll pin a reference pressure point. */
     PetscBool   isRefP;
     
     
@@ -262,4 +262,4 @@ protected:
     
     /** \brief Set null space or apply reference point.  */
     virtual PetscErrorCode setNullSpace();
-};
+}; // NavierStokesSolver

--- a/applications/tairacolonius/main.cpp
+++ b/applications/tairacolonius/main.cpp
@@ -25,13 +25,13 @@
  * \brief Implementation of parallel IBPM solver (Taira & Colonius 2007).
  * 
  * This is an example of using PetIBM to build a parallel incompressible flow 
- * solver with the immersed-boundary method prposed by Taira & Colonius 2007. 
+ * solver with the immersed-boundary method proposed by Taira & Colonius 2007. 
  * We name this solver \a IBPM.
  * 
  * If readers are interested in using this solver instead of coding,
  * please refer to 
  * \ref md_runpetibm "Running PetIBM",
- * \ref md_examples2d "2D Exmaples", and
+ * \ref md_examples2d "2D Examples", and
  * \ref md_examples3d "3D Examples".
  * 
  * \b Reference: \n

--- a/applications/tairacolonius/tairacolonius.cpp
+++ b/applications/tairacolonius/tairacolonius.cpp
@@ -37,7 +37,7 @@ TairaColoniusSolver::~TairaColoniusSolver()
     ierr = ISDestroy(&isDE[0]); CHKERRV(ierr);
     ierr = ISDestroy(&isDE[1]); CHKERRV(ierr);
     ierr = VecDestroy(&P); CHKERRV(ierr);
-}
+} // ~TairaColoniusSolver
 
 
 // manual destroy data
@@ -54,7 +54,7 @@ PetscErrorCode TairaColoniusSolver::destroy()
     ierr = NavierStokesSolver::destroy(); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // finalize
+} // destroy
 
 
 PetscErrorCode TairaColoniusSolver::initialize(
@@ -158,7 +158,7 @@ PetscErrorCode TairaColoniusSolver::createOperators()
     ierr = MatDestroy(&BN); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-} // assembleOperators
+} // createOperators
 
 
 // create vectors
@@ -190,7 +190,7 @@ PetscErrorCode TairaColoniusSolver::createVectors()
     ierr = NavierStokesSolver::createVectors(); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // createVectors
 
 
 PetscErrorCode TairaColoniusSolver::setNullSpace()
@@ -235,7 +235,7 @@ PetscErrorCode TairaColoniusSolver::setNullSpace()
     }
     
     PetscFunctionReturn(0);
-}
+} // setNullSpace
 
 
 // prepare tight-hand-side vector for Poisson system
@@ -310,7 +310,7 @@ PetscErrorCode TairaColoniusSolver::writeRestartData(const std::string &filePath
     ierr = VecRestoreSubVector(solution->pGlobal, isDE[1], &f); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // writeRestartData
 
 
 // read data necessary for restarting
@@ -340,7 +340,7 @@ PetscErrorCode TairaColoniusSolver::readRestartData(const std::string &filePath)
     ierr = VecRestoreSubVector(solution->pGlobal, isDE[1], &f[0]); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // readRestartData
 
 
 // write averaged forces

--- a/applications/tairacolonius/tairacolonius.h
+++ b/applications/tairacolonius/tairacolonius.h
@@ -71,7 +71,7 @@ public:
      * \brief Write the extra data that are required for restarting sessions.
      * 
      * If the file already has solutions in it, only extra necessary data will
-     * be writen in. Otherwise, solutions and extra data will all be writen in.
+     * be written in. Otherwise, solutions and extra data will all be written in.
      *
      * \param filePath [in] path of the file to save (without the extension)
      */
@@ -122,4 +122,4 @@ protected:
     
     /** \brief Set null space or apply reference point.  */
     virtual PetscErrorCode setNullSpace();
-};
+}; // TairaColoniusSolver

--- a/applications/vorticity/main.cpp
+++ b/applications/vorticity/main.cpp
@@ -30,7 +30,7 @@
  * \brief A post-processing utility that calculates vorticity fields.
  * 
  * This is a helper utility built with PetIBM components, and it calculates
- * the vorticity fileds of simulation results from the
+ * the vorticity field of simulation results from the
  * \ref nssolver "Navier-Stokes solver",
  * \ref tairacolonius "IBPM solver", and 
  * \ref decoupledibpm "decoupled IBPM solver".
@@ -38,7 +38,7 @@
  * If readers are interested in using this utility,
  * please refer to 
  * \ref md_runpetibm "Running PetIBM",
- * \ref md_examples2d "2D Exmaples", and
+ * \ref md_examples2d "2D Examples", and
  * \ref md_examples3d "3D Examples".
  * 
  * \ingroup apps
@@ -156,14 +156,14 @@ int main(int argc, char **argv)
         else
         { ierr = calculateVorticity3D(mesh, bc, soln, wDMs, w); CHKERRQ(ierr); }
 
-        // append to existing hdf5 file
+        // append to existing HDF5 file
         ierr = petibm::io::writeHDF5Vecs(mesh->comm, ss.str(), "/",
                 wNames, w, FILE_MODE_APPEND); CHKERRQ(ierr);
 
         ierr = PetscPrintf(PETSC_COMM_WORLD, "done.\n"); CHKERRQ(ierr);
     }
 
-    // destroy everything from petsc
+    // destroy everything from PETSc
     for(unsigned int f=0; f<w.size(); ++f)
     {
         ierr = VecDestroy(&w[f]); CHKERRQ(ierr);
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
     ierr = PetscFinalize(); CHKERRQ(ierr);
 
     return 0;
-}
+} // main
 
 
 PetscErrorCode calculateVorticity2D(const petibm::type::Mesh &mesh, 
@@ -253,7 +253,7 @@ PetscErrorCode calculateVorticity2D(const petibm::type::Mesh &mesh,
     }
 
     PetscFunctionReturn(0);
-}
+} // calculateVorticity2D
 
 
 PetscErrorCode calculateVorticity3D(const petibm::type::Mesh &mesh, 
@@ -394,7 +394,7 @@ PetscErrorCode calculateVorticity3D(const petibm::type::Mesh &mesh,
     }
 
     PetscFunctionReturn(0);
-}
+} // calculateVorticity3D
 
 
 PetscErrorCode initVorticityMesh(const petibm::type::Mesh &mesh, 
@@ -424,7 +424,7 @@ PetscErrorCode initVorticityMesh(const petibm::type::Mesh &mesh,
         coord[0][1].assign(mesh->coord[4][1], mesh->coord[4][1]+n[0][1]);
         coord[0][2].assign(mesh->coord[3][2], mesh->coord[3][2]+n[0][2]);
 
-        // name of vorticity fileds
+        // name of vorticity fields
         names = std::vector<std::string>(1);
 
         // set name for wz
@@ -482,7 +482,7 @@ PetscErrorCode initVorticityMesh(const petibm::type::Mesh &mesh,
         coord[2][1].assign(mesh->coord[4][1], mesh->coord[4][1]+n[2][1]);
         coord[2][2].assign(mesh->coord[3][2], mesh->coord[3][2]+n[2][2]);
 
-        // name of vorticity fileds
+        // name of vorticity fields
         names = std::vector<std::string>(3);
 
         // set name for wx
@@ -516,4 +516,4 @@ PetscErrorCode initVorticityMesh(const petibm::type::Mesh &mesh,
         }
     }
     PetscFunctionReturn(0);
-}
+} // initVorticityMesh

--- a/include/petibm/bodypack.h
+++ b/include/petibm/bodypack.h
@@ -1,7 +1,7 @@
 /**
  * \file bodypack.h
  * \brief body::BodyPackBase, type::BodyPack, and factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -29,16 +29,16 @@
 
 /**
  * \defgroup bodyModule Immersed-boundary bodies
- * \brief Objecs related to immersed-boundary bodies.
+ * \brief Objects related to immersed-boundary bodies.
  * 
  * This module contains objects related to immersed-boundary bodies and factory
  * functions.
  * 
  * A petibm::type::SingleBody is an object holding information of a single body,
- * including coordinates of Lagragian points, and the indices of relevant background
+ * including coordinates of Lagrangian points, and the indices of relevant background
  * Eulerian mesh points, etc. It also has member functions regarding to a single
  * body. For example, to update the indices of relevant Eulerian mesh points, 
- * I/O, calcaulating forces, etc. A petibm::type::SingleBody is distributed to
+ * I/O, calculating forces, etc. A petibm::type::SingleBody is distributed to
  * all MPI processes regardless the decomposition of the background Eulerian mesh.
  * It also handles the indexing of Lagrangian points in a parallel PETSc Vec.
  * 
@@ -76,7 +76,7 @@ namespace body
  * This class is designed to be an abstract class though, it actually has full
  * implementations of all members because there is currently no necessary to do
  * otherwise. It's just simply a collection of bodies, though it also deals with
- * indexing of all Lagragian points in a globally packed Vec.
+ * indexing of all Lagrangian points in a globally packed Vec.
  */
 class BodyPackBase
 {
@@ -150,7 +150,7 @@ public:
 
 
     /**
-     * \brief Find un-packed global index of a DoF of Lagrangian point of a body.
+     * \brief Find unpacked global index of a DoF of Lagrangian point of a body.
      *
      * \param bIdx [in] index of target body.
      * \param ptIdx [in] index of target point.
@@ -164,11 +164,11 @@ public:
 
 
     /**
-     * \brief Find un-packed global index of a DoF of Lagrangian point of a body.
+     * \brief Find unpacked global index of a DoF of Lagrangian point of a body.
      *
      * \param bIdx [in] index of target body.
      * \param s [in] MatStencil of target point.
-     * \param idx [in] returned un-packed global index.
+     * \param idx [in] returned unpacked global index.
      *
      * \return PetscErrorCode.
      */
@@ -220,7 +220,7 @@ public:
     
     
     /**
-     * \brief Update the indices of backgrounf Pressure cells for all body.
+     * \brief Update the indices of background Pressure cells for all body.
      *
      * \return PetscErrorCode.
      */
@@ -239,7 +239,7 @@ protected:
     PetscErrorCode init(const type::Mesh &mesh, const YAML::Node &node);
     
 
-    /** \brief Reference to backgrounf mesh. */
+    /** \brief Reference to background mesh. */
     type::Mesh          mesh;
 
 
@@ -277,7 +277,7 @@ protected:
      * \return PetscErrorCode.
      */
     PetscErrorCode createInfoString();
-};
+}; // BodyPackBase
 
 } // end of namespace body
 

--- a/include/petibm/boundary.h
+++ b/include/petibm/boundary.h
@@ -1,7 +1,7 @@
 /**
  * \file boundary.h
  * \brief boundary::BoundaryBase, type::Boundary, and factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -121,7 +121,7 @@ public:
     virtual PetscErrorCode setGhostICs(const type::Solution &soln) = 0;
 
     /**
-     * \brief Update the euqations between ghost and boundary points.
+     * \brief Update the equations between ghost and boundary points.
      * \param soln [in] a Solution object.
      * \param dt [in] time-step size.
      * \return PetscErrorCode.
@@ -166,7 +166,7 @@ protected:
     /** \brief A shared_ptr to underlying mesh. */
     type::Mesh                          mesh;
 
-};
+}; // BoundaryBase
 } // end of namespace boundary
 
 

--- a/include/petibm/boundarysimple.h
+++ b/include/petibm/boundarysimple.h
@@ -1,7 +1,7 @@
 /**
  * \file boundarysimple.h
  * \brief Definition of boundary::BoundarySimple
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -57,6 +57,6 @@ protected:
     // implementation of BoundaryBase::init
     virtual PetscErrorCode init(const type::Mesh &mesh, const YAML::Node &node);
 
-};
+}; // BoundarySimple
 } // end of namespace boundary
 } // end of namespace petibm

--- a/include/petibm/cartesianmesh.h
+++ b/include/petibm/cartesianmesh.h
@@ -1,7 +1,7 @@
 /**
  * \file cartesianmesh.h
  * \brief Definition of class mesh::CartesianMesh.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -114,7 +114,7 @@ protected:
      *         all processes. */
     type::IntVec1D          UPackNLocalAllProcs;
 
-    /** \brief Offsets of velocity points in un-packed DMs for all processes and
+    /** \brief Offsets of velocity points in unpacked DMs for all processes and
      *         all velocity field. */
     type::IntVec2D          offsetsAllProcs;
 
@@ -173,7 +173,7 @@ protected:
     PetscErrorCode createPressureDMDA();
 
     /**
-     * \brief Create DMDAs for velovity fields and make a DMComposite.
+     * \brief Create DMDAs for velocity fields and make a DMComposite.
      * \return PetscErrorCode.
      */
     PetscErrorCode createVelocityPack();

--- a/include/petibm/delta.h
+++ b/include/petibm/delta.h
@@ -1,7 +1,7 @@
 /**
  * \file delta.h
  * \brief Prototype of Delta functions.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -18,7 +18,7 @@
 namespace petibm
 {
 /**
- * \brief A namespace of all kinds of descritized delta functions.
+ * \brief A namespace of all kinds of discretized delta functions.
  * \ingroup miscModule
  */
 namespace delta

--- a/include/petibm/io.h
+++ b/include/petibm/io.h
@@ -1,7 +1,7 @@
 /**
  * \file io.h
  * \brief Prototypes of I/O functions.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -32,7 +32,7 @@ namespace io
 /**
  * \brief Read the number and coordinates of Lagrangian points from a file.
  * \param file [in] the path to the file.
- * \param nPts [out] the total number of Lagragian points.
+ * \param nPts [out] the total number of Lagrangian points.
  * \param coords [out] 2D STL vector of coordinates.
  * \return PetscErrorCode.
  * \ingroup miscModule
@@ -50,10 +50,10 @@ PetscErrorCode print(const std::string &info);
 
 
 /**
- * \brief Wirte a vector of Vecs with names to a HDF5 file.
+ * \brief Write a vector of Vecs with names to a HDF5 file.
  * \param comm [in] MPI communicator (should be the same as the one in Vecs).
  * \param file [in] file path + file name (without extension).
- * \param loc [in] where in the HDF5 file tha data will be writen in.
+ * \param loc [in] where in the HDF5 file that data will be written in.
  * \param names [in] a std::vector of std::string for the names of the Vecs.
  * \param vecs [in] a std::vector of Vecs.
  * \param mode [in] either FILE_MODE_WRITE (default) or FILE_MODE_APPEND.
@@ -68,10 +68,10 @@ PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file,
 
 
 /**
- * \brief Wirte a vector of raw arrays with names to a HDF5 file.
+ * \brief Write a vector of raw arrays with names to a HDF5 file.
  * \param comm [in] MPI communicator.
  * \param file [in] file path + file name (without extension).
- * \param loc [in] where in the HDF5 file tha data will be writen in.
+ * \param loc [in] where in the HDF5 file that data will be written in.
  * \param names [in] a std::vector of std::string for the names of each array.
  * \param n [in] a std::vector of integer for the length of each array.
  * \param vecs [in] a std::vector of raw arrays (i.e., PetscReal*).
@@ -88,10 +88,10 @@ PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file,
 
 
 /**
- * \brief Wirte type::RealVec2D with names to a HDF5 file.
+ * \brief Write type::RealVec2D with names to a HDF5 file.
  * \param comm [in] MPI communicator.
  * \param file [in] file path + file name (without extension).
- * \param loc [in] where in the HDF5 file tha data will be writen in.
+ * \param loc [in] where in the HDF5 file that data will be written in.
  * \param names [in] a std::vector of std::string for the names of each RealVec1D.
  * \param vecs [in] a type::RealVec2D, i.e., std::vector<type::RealVec1D>.
  * \param mode [in] either FILE_MODE_WRITE (default) or FILE_MODE_APPEND.
@@ -109,7 +109,7 @@ PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file,
  * \brief read a vector of Vecs matching the provided names from a HDF5 file.
  * \param comm [in] MPI communicator (should be the same as the one in Vecs).
  * \param file [in] file path + file name (without extension).
- * \param loc [in] where in the HDF5 file tha data will be read from.
+ * \param loc [in] where in the HDF5 file that data will be read from.
  * \param names [in] a std::vector of std::string for the names of the Vecs.
  * \param vecs [out] a std::vector of Vecs.
  * \return PetscErrorCode.

--- a/include/petibm/linsolver.h
+++ b/include/petibm/linsolver.h
@@ -176,7 +176,7 @@ protected:
     virtual PetscErrorCode init() = 0;
 
 }; // LinSolver
-}
+} // end of namespace linsolver
 
 
 namespace type
@@ -186,7 +186,7 @@ namespace type
      * Please use petibm::linsolver::createLinSolver to create a LinSolver 
      * instance.
      * 
-     * Exmaple Usage:
+     * Example Usage:
      * \code
      * PetscErrorCode ierr;
      * Mat A;
@@ -204,7 +204,7 @@ namespace type
      * \ingroup linsolver
      */
     typedef std::shared_ptr<linsolver::LinSolverBase> LinSolver;
-}
+} // end of namespace type
 
 
 namespace linsolver
@@ -247,6 +247,6 @@ namespace linsolver
      */
     PetscErrorCode createLinSolver(const std::string &solverName,
             const YAML::Node &node, type::LinSolver &solver);
-}
+} // end of namespace linsolver
 
 } // end of namespace petibm

--- a/include/petibm/mesh.h
+++ b/include/petibm/mesh.h
@@ -1,7 +1,7 @@
 /**
  * \file mesh.h
  * \brief Prototype of mesh::MeshBase, type::Mesh, and factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -38,7 +38,7 @@
  * derived from the base class: \ref petibm::mesh::CartesianMesh "CartesianMesh".
  * 
  * The design of PetIBM is to use `std::shared_ptr` to hold the base class for
- * instances of different kinds of derived classes, so that we can call the pubilc 
+ * instances of different kinds of derived classes, so that we can call the public 
  * APIs regardless the types of the derived classes. \ref petibm::type::Mesh "Mesh" 
  * is defined as a shared pointer to \ref petibm::mesh::MeshBase "MeshBase". Users
  * should use \ref petibm::type::Mesh "Mesh" instead of using classes directly. 
@@ -47,7 +47,7 @@
  * instances directly.
  * 
  * The domain decomposition is done with PETSc DMDA objects. And the information
- * of subdomains are retrieved into mesh classes.
+ * of sub-domains are retrieved into mesh classes.
  * 
  * \see petibm::type::Mesh, petibm::mesh::createMesh
  * \ingroup petibm
@@ -111,7 +111,7 @@ public:
     /** \brief Number of processes in all directions. */
     type::IntVec1D          nProc;
 
-    /** \brief The beginging index of all fields in all directions of this process. */
+    /** \brief The beginning index of all fields in all directions of this process. */
     type::IntVec2D          bg;
 
     /** \brief The ending index of all fields in all directions of this process. */
@@ -173,7 +173,7 @@ public:
     
 
     /**
-     * \brief Print iformation to standard output.
+     * \brief Print information to standard output.
      *
      * \return PetscErrorCode.
      */
@@ -262,12 +262,12 @@ public:
 
 
     /**
-     * \brief Get the global index of a point in un-packed DM by 
+     * \brief Get the global index of a point in unpacked DM by 
      *        providing MatStencil.
      *
      * \param f [in] target field (u=0, v=1, w=2, p=3).
      * \param s [in] MatStencil of target point.
-     * \param idx [out] global index in un-packed DM.
+     * \param idx [out] global index in unpacked DM.
      * 
      * If the provided MatStencil is not valid or is a ghost point, the `idx`
      * will be `-1`.
@@ -279,14 +279,14 @@ public:
 
 
     /**
-     * \brief Get the global index of a point in un-packed DM by providing
+     * \brief Get the global index of a point in unpacked DM by providing
      *        i, j, and k.
      *
      * \param f [in] target field (u=0, v=1, w=2, p=3).
      * \param i [in] i-index.
      * \param j [in] j-index.
      * \param k [in] k-index.
-     * \param idx [out] global index in un-packed DM.
+     * \param idx [out] global index in unpacked DM.
      *
      * For 2D mesh, the value of k-index will be ignored.
      * 
@@ -389,7 +389,7 @@ namespace type
      * \ingroup meshModule
      */
     typedef std::shared_ptr<mesh::MeshBase> Mesh;
-} // end of type
+} // end of namespace type
 
 
 namespace mesh

--- a/include/petibm/misc.h
+++ b/include/petibm/misc.h
@@ -1,7 +1,7 @@
 /**
  * \file misc.h
  * \brief Prototypes of some miscellaneous functions.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -164,7 +164,7 @@ namespace misc
         for(auto it=dL.begin()+1; it<dL.end(); ++it) *it = *(it -1) * r;
 
         PetscFunctionReturn(0);
-    }
+    } // stretchGrid
 
 
     /**
@@ -198,7 +198,7 @@ namespace misc
                 
 
         PetscFunctionReturn(0);
-    }
+    } // doubleLoops
 
 
     /**
@@ -229,7 +229,7 @@ namespace misc
         }
 
         PetscFunctionReturn(0);
-    }
+    } // tripleLoops
 
 } // end of namespace misc
 } // end of namespace petibm

--- a/include/petibm/operators.h
+++ b/include/petibm/operators.h
@@ -1,7 +1,7 @@
 /**
  * \file operators.h
  * \brief Prototypes of factory functions for operators.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -33,9 +33,9 @@
  * only make sense to staggered Cartesian CFD methods. So the operator factories
  * can not create the operators for arbitrary fields. For example, 
  * \ref petibm::operators::createLaplacian "createLaplacian" can only create 
- * Laplacian for velocity fields because in our CFD framwork (Perot 1993), only 
- * the Laplacian of velocity fields is required. This factory function can not 
- * create Laplacians for arbitrary fields.
+ * Laplacian for velocity fields because in our CFD framework (Perot 1993), only 
+ * the Laplacian of velocity fields is required. This factory function cannot 
+ * create Laplacian operators for arbitrary fields.
  * 
  * For operators taking boundary conditions, we decouple the interior part and
  * boundary corrections. For example, applying a divergence operator to velocity
@@ -224,7 +224,7 @@ PetscErrorCode createGradient(const type::Mesh &mesh,
  * The divergence operator calculates the divergence of velocity on pressure 
  * points. The complete divergence operator is \f$(D+D_{bc})\f$. However, the 
  * boundary correction, \f$D_{bc}\f$, represents the constant coefficients (it 
- * means the coefficients that have nothing to do with interior points, thouth
+ * means the coefficients that have nothing to do with interior points, though
  * it may still be time-dependent) in ghost point schemes, so it's safe to put
  * the boundary correction to right-hand side in a linear system.
  *
@@ -263,7 +263,7 @@ PetscErrorCode createLaplacian(const type::Mesh &mesh,
 
 
 /**
- * \brief Create a matrix-free Mat for convection operater, \f$H\f$.
+ * \brief Create a matrix-free Mat for convection operator, \f$H\f$.
  * \param mesh [in] an instance of petibm::type::Mesh.
  * \param bc [in] an instance of petibm::type::Boundary.
  * \param H [out] a PETSc Mat; the returned operator, \f$H\f$.
@@ -365,7 +365,7 @@ PetscErrorCode createBn(const Mat &Op, const Mat &M, const PetscReal &dt,
  * \param Delta [out] a PETSc Mat; returned \f$Delta\f$.
  * \return PetscErrorCode.
  *
- * In \f$Delta\f$, rows represent Lagrangian points, while columes represent 
+ * In \f$Delta\f$, rows represent Lagrangian points, while columns represent 
  * velocity mesh points.
  * 
  * An entry in \f$Delta\f$, says \f$Delta_{(i,j)}\f$, is defined as

--- a/include/petibm/parser.h
+++ b/include/petibm/parser.h
@@ -1,7 +1,7 @@
 /**
  * \file parser.h
  * \brief Prototypes of parser functions.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -43,13 +43,13 @@ namespace parser
      * -# `-config`: location of config.yaml. If not provided, the default is
      *    [working directory]/config.yaml.
      * -# `-mesh`: location of mesh.yaml. This provides a way to overwrite the
-     *    mesh section indide config.yaml.
+     *    mesh section inside config.yaml.
      * -# `-flow`: location of flow.yaml. This provides a way to overwrite the
-     *    flow section indide config.yaml.
+     *    flow section inside config.yaml.
      * -# `-parameters`: location of parameters.yaml. This provides a way to 
-     *    overwrite the parameters section indide config.yaml.
+     *    overwrite the parameters section inside config.yaml.
      * -# `-bodies`: location of bodies.yaml. This provides a way to overwrite
-     *    the bodies section indide config.yaml.
+     *    the bodies section inside config.yaml.
      *
      * If users provide non-empty YAML node as input, the data inside the node
      * will be discarded.
@@ -92,7 +92,7 @@ namespace parser
             PetscReal &ed, PetscInt &nTotal, type::RealVec1D &dL);
 
     /**
-     * \brief Parse all subdomains in a direction.
+     * \brief Parse all sub-domains in a direction.
      * \param subs [in] the YAML node
      * \param bg [in] an input value providing starting of this direction.
      * \param nTotal [out] returned total number of pressure cells in this direction.
@@ -108,12 +108,12 @@ namespace parser
             PetscInt &nTotal, PetscReal &ed, type::RealVec1D &dL);
 
     /**
-     * \brief Parse only one subdomain
+     * \brief Parse only one sub-domain
      * \param sub [in] the YAML node
-     * \param bg [in] an input providing the starting of this subdomain.
-     * \param n [out] returned number of pressure cells in this subdomain.
-     * \param ed [out] returned ending of this subdomain.
-     * \param dL [out] returned 1D vector for sizes of pressure cells in this subdomain.
+     * \param bg [in] an input providing the starting of this sub-domain.
+     * \param n [out] returned number of pressure cells in this sub-domain.
+     * \param ed [out] returned ending of this sub-domain.
+     * \param dL [out] returned 1D vector for sizes of pressure cells in this sub-domain.
      * \return PetscErrorCode
      * \ingroup miscModule
      */
@@ -140,7 +140,7 @@ namespace parser
     /**
      * \brief Parse initial conditions from a YAML node.
      * \param node [in] a YAML node.
-     * \param icValues [out] IC values of different fileds.
+     * \param icValues [out] IC values of different fields.
      * \return PetscErrorCode.
      * \ingroup miscModule
      * 

--- a/include/petibm/singlebody.h
+++ b/include/petibm/singlebody.h
@@ -1,7 +1,7 @@
 /**
  * \file singlebody.h
  * \brief body::SingleBodyBase, type::SingleBody factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -57,7 +57,7 @@ public:
     /** \brief Coordinates of ALL Lagrangian points. */
     type::RealVec2D     coords;
 
-    /** \brief Number of Lagrangain points owned locally. */
+    /** \brief Number of Lagrangian points owned locally. */
     PetscInt            nLclPts;
 
     /**
@@ -89,7 +89,7 @@ public:
      * The information carried by `file` will be different according to different
      * implementations. For example, the `file` of the current only one 
      * implementation, body::SingleBodyPoints, is a file containing the 
-     * coordinates of all Lagragian points for this body.
+     * coordinates of all Lagrangian points for this body.
      */
     SingleBodyBase(const type::Mesh &mesh,
             const std::string &name, const std::string &file);
@@ -134,7 +134,7 @@ public:
 
 
     /**
-     * \brief Find the global index in un-packed DM of a specified DoF of a 
+     * \brief Find the global index in unpacked DM of a specified DoF of a 
      *        Lagrangian point.
      *
      * \param i [in] index of target Lagrangian point of this body.
@@ -148,7 +148,7 @@ public:
 
 
     /**
-     * \brief Find the global index in un-packed DM of specified DoF of a 
+     * \brief Find the global index in unpacked DM of specified DoF of a 
      *        Lagrangian point.
      *
      * \param s [in] MatStencil of target point and DoF.
@@ -196,17 +196,17 @@ protected:
     PetscMPIInt         mpiRank;
     
 
-    /** \brief Reference to backgrounf mesh. */
+    /** \brief Reference to background mesh. */
     type::Mesh          mesh;
 
 
-    /** \brief Number of varaibles (nLcLPts x dim) on each process. */
+    /** \brief Number of variables (nLcLPts x dim) on each process. */
     type::IntVec1D      nLclAllProcs;
 
 
     /** \brief Offset on each process. */
     type::IntVec1D      offsetsAllProcs;
-};
+}; // SingleBodyBase
 
 } // end of namespace body
 

--- a/include/petibm/singlebodypoints.h
+++ b/include/petibm/singlebodypoints.h
@@ -1,7 +1,7 @@
 /**
  * \file singlebodypoints.h
  * \brief Definition of body::SingleBodyPoints.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -87,7 +87,7 @@ protected:
     
     
     /**
-     * \brief Find the indices of presure cells that own local Lagrangian points.
+     * \brief Find the indices of pressure cells that own local Lagrangian points.
      *
      * \return PetscErrorCode.
      */
@@ -108,7 +108,7 @@ protected:
      * \return PetscErrorCode.
      */
     PetscErrorCode createInfoString();
-};
+}; // SingleBodyPoints
 
 } // end of namespace body
 } // end of namespace petibm

--- a/include/petibm/singleboundary.h
+++ b/include/petibm/singleboundary.h
@@ -1,7 +1,7 @@
 /**
  * \file singleboundary.h
  * \brief Definition of the class `SingleBoundaryBase`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -122,7 +122,7 @@ public:
      * 
      * In PetIBM, we use a global packed Vec for velocity fields. But in some
      * occasions, we may need local Vecs that have ghost points in them. So we
-     * have to copy the ghost values from this instance to the local Vesc.
+     * have to copy the ghost values from this instance to the local Vecs.
      */
     PetscErrorCode copyValues2LocalVec(Vec &lclVec);
 
@@ -174,7 +174,7 @@ protected:
     /** \brief The corresponding Mesh object. */
     type::Mesh      mesh;
 
-};
+}; // SingleBoundaryBase
 
 } // end of namespace boundary
 
@@ -189,7 +189,7 @@ namespace type
      * Please use petibm::boundary::createSingleBoundary to create a Mesh object.
      */
     typedef std::shared_ptr<boundary::SingleBoundaryBase> SingleBoundary;
-}
+} // end of namespace type
 
 namespace boundary
 {
@@ -213,6 +213,6 @@ namespace boundary
             const type::Field &field, const PetscReal &value,
             const type::BCType &bcType,
             type::SingleBoundary &singleBd);
-}
+} // end of namespace boundary
 
 } // end of namespace petibm

--- a/include/petibm/singleboundaryconvective.h
+++ b/include/petibm/singleboundaryconvective.h
@@ -1,7 +1,7 @@
 /**
  * \file singleboundaryconvective.h
  * \brief Definition of the class `SingleBoundaryConvective`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -70,7 +70,7 @@ protected:
             const PetscReal &targetValue, const PetscReal &dt, 
             const PetscReal &normal, const PetscReal &value,
             type::GhostPointInfo &p);
-};
+}; // SingleBoundaryConvective
 
 } // end of namespace boundary
 } // end of namespace petibm

--- a/include/petibm/singleboundarydirichlet.h
+++ b/include/petibm/singleboundarydirichlet.h
@@ -1,7 +1,7 @@
 /**
  * \file singleboundarydirichlet.h
  * \brief Definition of the class `SingleBoundaryDirichlet`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -51,7 +51,7 @@ protected:
     virtual PetscErrorCode updateEqsKernel(const PetscReal &targetValue,
             const PetscReal &dt, type::GhostPointInfo &p);
 
-};
+}; // SingleBoundaryDirichlet
 
 } // end of namespace boundary
 } // end of namespace petibm

--- a/include/petibm/singleboundaryneumann.h
+++ b/include/petibm/singleboundaryneumann.h
@@ -1,7 +1,7 @@
 /**
  * \file singleboundaryneumann.h
  * \brief Definition of the class `SingleBoundaryNeumann`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -51,7 +51,7 @@ protected:
     virtual PetscErrorCode updateEqsKernel(const PetscReal &targetValue,
             const PetscReal &dt, type::GhostPointInfo &p);
 
-};
+}; // SingleBoundaryNeumann
 
 } // end of namespace boundary
 } // end of namespace petibm

--- a/include/petibm/singleboundaryperiodic.h
+++ b/include/petibm/singleboundaryperiodic.h
@@ -1,7 +1,7 @@
 /**
  * \file singleboundaryperiodic.h
  * \brief Definition of the class `SingleBoundaryPeriodic`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -54,7 +54,7 @@ protected:
     virtual PetscErrorCode updateEqsKernel(const PetscReal &targetValue,
             const PetscReal &dt, type::GhostPointInfo &p);
 
-};
+}; // SingleBoundaryPeriodic
 
 } // end of namespace boundary
 } // end of namespace petibm

--- a/include/petibm/solution.h
+++ b/include/petibm/solution.h
@@ -1,7 +1,7 @@
 /**
  * \file solution.h
  * \brief Definition of solution::SolutionBase, type::Solution, and factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -33,7 +33,7 @@
  * petibm::type::Solution to access this only-one implementation.
  * The flow solvers implemented in PetIBM
  * currently don't need other types of implementation, but using an abstract 
- * class provides potential to expand this catogery in the future.
+ * class provides potential to expand this category in the future.
  * 
  * \see petibm::type::Solution, petibm::solution::createSolution
  * \ingroup petibm
@@ -173,7 +173,7 @@ protected:
     /** \brief A std::shared_ptr to underlying mesh. */
     type::Mesh                              mesh;
 
-};
+}; // SolutionBase
 } // end of namespace solution
 
 
@@ -203,7 +203,7 @@ namespace type
      * \ingroup solutionModule
      */
     typedef std::shared_ptr<solution::SolutionBase> Solution;
-}
+} // end of namespace type
 
 
 namespace solution
@@ -222,6 +222,6 @@ namespace solution
      */
     PetscErrorCode createSolution(
             const type::Mesh &mesh, type::Solution &solution);
-}
+} // end of namespace solution
 
 } // end of namespace petibm

--- a/include/petibm/solutionsimple.h
+++ b/include/petibm/solutionsimple.h
@@ -1,7 +1,7 @@
 /**
  * \file solutionsimple.h
  * \brief Definition of class solution::SolutionSimple.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -64,6 +64,6 @@ protected:
      * \return PetscErrorCode.
      */
     PetscErrorCode createInfoString();
-};
+}; // SolutionSimple
 } // end of namespace solution
 } // end of namespace petibm

--- a/include/petibm/timeintegration.h
+++ b/include/petibm/timeintegration.h
@@ -1,7 +1,7 @@
 /**
  * \file timeintegration.h
  * \brief Definition of TimeIntegration related classes.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -25,7 +25,7 @@
 
 
 /**
- * \defgroup timeModule Time integration schemes
+ * \defgroup timeModule Time-integration schemes
  * \brief Objects holding informations of time-integration schemes.
  * 
  * API users should use petibm::timeintegration::createTimeIntegration to
@@ -58,7 +58,7 @@ public:
     /** \brief Name of the scheme. */
     const std::string                 scheme;
 
-    /** \brief Coefficient of inplicit term. */
+    /** \brief Coefficient of implicit term. */
     const PetscReal                   implicitCoeff;
 
     /** \brief Number of explicit terms. */
@@ -77,7 +77,7 @@ public:
      * \param inScheme [in] the name of the scheme.
      * \param inImplicitCoeff [in] implicit coefficient.
      * \param inNEcplicit [in] number of explicit coefficients.
-     * \param inExplicitCoeffs [in] a std::vector holding all explit coefficients.
+     * \param inExplicitCoeffs [in] a std::vector holding all explicit coefficients.
      */
     TimeIntegrationBase(
             const std::string &inName,
@@ -119,7 +119,7 @@ public:
     
     /** \copydoc TimeIntegrationBase::~TimeIntegrationBase */
     virtual ~Euler_Explicit() = default;
-};
+}; // Euler_Explicit
 
 
 /** 
@@ -140,7 +140,7 @@ public:
     
     /** \copydoc TimeIntegrationBase::~TimeIntegrationBase */
     virtual ~Euler_Implicit() = default;
-};
+}; // Euler_Implicit
 
 
 /** 
@@ -161,7 +161,7 @@ public:
     
     /** \copydoc TimeIntegrationBase::~TimeIntegrationBase */
     virtual ~Adams_Bashforth_2() = default;
-};
+}; // Adams_Bashforth_2
 
 
 /** 
@@ -182,7 +182,7 @@ public:
     
     /** \copydoc TimeIntegrationBase::~TimeIntegrationBase */
     virtual ~Crank_Nicolson() = default;
-};
+}; // Crank_Nicolson
 
 } // end of namespace timeintegration
 
@@ -195,7 +195,7 @@ namespace type
      * \ingroup timeModule
      */
     typedef std::shared_ptr<timeintegration::TimeIntegrationBase> TimeIntegration;
-}
+} // end of namespace type
 
 
 namespace timeintegration
@@ -212,6 +212,6 @@ namespace timeintegration
     PetscErrorCode createTimeIntegration(
             const std::string &name, const YAML::Node &node,
             type::TimeIntegration &integration);
-}
+} // end of namespace timeintegration
 
 } // end of namespace petibm

--- a/include/petibm/type.h
+++ b/include/petibm/type.h
@@ -23,7 +23,7 @@
  * \defgroup petibm Building blocks for building flow solvers 
  * 
  * This part contains building blocks that are necessary for a flow solver in 
- * Perot (1993) framwork and staggered-grid finite difference method.
+ * Perot (1993) framework and staggered-grid finite difference method.
  */
 
 
@@ -51,8 +51,8 @@
 /** 
  * \brief Operator< of MatStencil for using it as a key to map. 
  *
- * For the detail of implimentation, please refer to 
- * std::lexicographical_compare. This is just a splified version.
+ * For the detail of implementation, please refer to 
+ * std::lexicographical_compare. This is just a simplified version.
  */
 bool operator<(const MatStencil &, const MatStencil &);
 
@@ -136,7 +136,7 @@ namespace type
     struct GhostPointInfo
     {
         PetscInt    lclId; ///< the index in a local velocity vector of this ghost point
-        MatStencil  targetStencil; ///< the tencil of point corresponding to this ghost point
+        MatStencil  targetStencil; ///< the stencil of point corresponding to this ghost point
         PetscInt    targetPackedId; ///< the index of target point in global packed velocity vector
         PetscReal   area; ///< the flux area of this ghost point
         PetscReal   dL; ///< the distance between this ghost point and target velocity point

--- a/include/petibm/yaml.h
+++ b/include/petibm/yaml.h
@@ -1,7 +1,7 @@
 /**
  * \file yaml.h
  * \brief Prototypes of YAML converters.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -37,7 +37,7 @@ namespace YAML
         static bool decode(const Node &node, petibm::type::Dir &dir);
     };
 
-    /** \brief converter for `tpyes::Field` */
+    /** \brief converter for `types::Field` */
     template <>
     struct convert<petibm::type::Field>
     {

--- a/src/body/bodypack.cpp
+++ b/src/body/bodypack.cpp
@@ -1,7 +1,7 @@
 /**
  * \file bodypack.cpp
  * \brief Implementations of body::BodyPackBase and factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -22,7 +22,7 @@ namespace body
 BodyPackBase::BodyPackBase(const type::Mesh &inMesh, const YAML::Node &node)
 {
     init(inMesh, node);
-}
+} // BodyPackBase
 
 
 BodyPackBase::~BodyPackBase()
@@ -36,7 +36,7 @@ BodyPackBase::~BodyPackBase()
 
     ierr = DMDestroy(&dmPack); CHKERRV(ierr);
     comm = MPI_COMM_NULL;
-}
+} // ~BodyPackBase
 
 
 PetscErrorCode BodyPackBase::destroy()
@@ -57,7 +57,7 @@ PetscErrorCode BodyPackBase::destroy()
     type::IntVec1D().swap(offsetsAllProcs);
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 
 PetscErrorCode BodyPackBase::init(
@@ -143,7 +143,7 @@ PetscErrorCode BodyPackBase::init(
     ierr = createInfoString(); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // init
 
 
 PetscErrorCode BodyPackBase::createDmPack()
@@ -160,7 +160,7 @@ PetscErrorCode BodyPackBase::createDmPack()
     }
 
     PetscFunctionReturn(0);
-}
+} // createDmPack
 
 
 PetscErrorCode BodyPackBase::createInfoString()
@@ -189,7 +189,7 @@ PetscErrorCode BodyPackBase::createInfoString()
     }
 
     PetscFunctionReturn(0);
-}
+} // createInfoString
 
 
 PetscErrorCode BodyPackBase::printInfo() const
@@ -206,7 +206,7 @@ PetscErrorCode BodyPackBase::printInfo() const
     }
 
     PetscFunctionReturn(0);
-}
+} // printInfo
 
 
 PetscErrorCode BodyPackBase::findProc(
@@ -224,7 +224,7 @@ PetscErrorCode BodyPackBase::findProc(
     ierr = bodies[bIdx]->findProc(ptIdx, proc); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // findProc
 
 
 PetscErrorCode BodyPackBase::getGlobalIndex(const PetscInt &bIdx, 
@@ -242,7 +242,7 @@ PetscErrorCode BodyPackBase::getGlobalIndex(const PetscInt &bIdx,
     ierr = bodies[bIdx]->getGlobalIndex(ptIdx, dof, idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getGlobalIndex
 
 
 PetscErrorCode BodyPackBase::getGlobalIndex(
@@ -255,7 +255,7 @@ PetscErrorCode BodyPackBase::getGlobalIndex(
     ierr = getGlobalIndex(bIdx, s.i, s.c, idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getGlobalIndex
 
 
 PetscErrorCode BodyPackBase::getPackedGlobalIndex(const PetscInt &bIdx, 
@@ -280,7 +280,7 @@ PetscErrorCode BodyPackBase::getPackedGlobalIndex(const PetscInt &bIdx,
     idx += (unPackedIdx - bodies[bIdx]->offsetsAllProcs[p]);
 
     PetscFunctionReturn(0);
-}
+} // getPackedGlobalIndex
 
 
 PetscErrorCode BodyPackBase::getPackedGlobalIndex(
@@ -293,7 +293,7 @@ PetscErrorCode BodyPackBase::getPackedGlobalIndex(
     ierr = getPackedGlobalIndex(bIdx, s.i, s.c, idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getPackedGlobalIndex
 
 
 PetscErrorCode BodyPackBase::calculateAvgForces(
@@ -320,7 +320,7 @@ PetscErrorCode BodyPackBase::calculateAvgForces(
             dmPack, f, nBodies, nullptr, unPacked.data()); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // calculateAvgForces
 
 
 PetscErrorCode createBodyPack(const type::Mesh &mesh,
@@ -331,6 +331,6 @@ PetscErrorCode createBodyPack(const type::Mesh &mesh,
     bodies = std::make_shared<BodyPackBase>(mesh, node);
     
     PetscFunctionReturn(0);
-}
+} // createBodyPack
 } // end of namespace body
 } // end of namespace petibm

--- a/src/body/singlebody.cpp
+++ b/src/body/singlebody.cpp
@@ -1,7 +1,7 @@
 /**
  * \file singlebody.cpp
  * \brief Implementations of body::SingleBodyBase and factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -42,7 +42,7 @@ SingleBodyBase::SingleBodyBase(const type::Mesh &inMesh,
     // allocate vectors
     nLclAllProcs = type::IntVec1D(mpiSize, 0);
     offsetsAllProcs = type::IntVec1D(mpiSize, 0);
-}
+} // SingleBodyBase
 
 
 SingleBodyBase::~SingleBodyBase()
@@ -56,7 +56,7 @@ SingleBodyBase::~SingleBodyBase()
 
     ierr = DMDestroy(&da); CHKERRV(ierr);
     comm = MPI_COMM_NULL;
-}
+} // ~SingleBodyBase
 
 
 PetscErrorCode SingleBodyBase::destroy()
@@ -77,7 +77,7 @@ PetscErrorCode SingleBodyBase::destroy()
     type::IntVec1D().swap(offsetsAllProcs);
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 
 PetscErrorCode SingleBodyBase::printInfo() const
@@ -86,7 +86,7 @@ PetscErrorCode SingleBodyBase::printInfo() const
     PetscErrorCode  ierr;
     ierr = io::print(info); CHKERRQ(ierr);
     PetscFunctionReturn(0);
-}
+} // printInfo
 
 
 PetscErrorCode createSingleBody(
@@ -103,7 +103,7 @@ PetscErrorCode createSingleBody(
                 "The type of mesh file \"%s\" is not recognized!\n", type.c_str());
     
     PetscFunctionReturn(0);
-}
+} // createSingleBody
 
 } // end of namespace body
 } // end of namespace petibm

--- a/src/body/singlebodypoints.cpp
+++ b/src/body/singlebodypoints.cpp
@@ -1,7 +1,7 @@
 /**
  * \file singlebodypoints.cpp
  * \brief Implementation of body::SingleBodyPoints.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -27,7 +27,7 @@ SingleBodyPoints::SingleBodyPoints(const type::Mesh &inMesh,
     SingleBodyBase(inMesh, inName, inFile)
 {
     init(inMesh, inName, inFile);
-}
+} // SingleBodyPoints
 
 
 PetscErrorCode SingleBodyPoints::init(const type::Mesh &inMesh, 
@@ -62,7 +62,7 @@ PetscErrorCode SingleBodyPoints::init(const type::Mesh &inMesh,
     ierr = createInfoString(); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // init
 
 
 PetscErrorCode SingleBodyPoints::createDMDA()
@@ -92,12 +92,12 @@ PetscErrorCode SingleBodyPoints::createDMDA()
     // each point has "dim" degree of freedom, so we have to multiply that
     for(auto &it: nLclAllProcs) it *= dim;
 
-    // calculate the offset of the un-packed DM
+    // calculate the offset of the unpacked DM
     for(PetscMPIInt r=mpiSize-1; r>0; r--) offsetsAllProcs[r] = nLclAllProcs[r-1];
     for(PetscMPIInt r=1; r<mpiSize; r++) offsetsAllProcs[r] += offsetsAllProcs[r-1];
 
     PetscFunctionReturn(0);
-}
+} // createDMDA
 
 
 PetscErrorCode SingleBodyPoints::updateMeshIdx()
@@ -123,7 +123,7 @@ PetscErrorCode SingleBodyPoints::updateMeshIdx()
     }
 
     PetscFunctionReturn(0);
-}
+} // updateMeshIdx
 
 
 PetscErrorCode SingleBodyPoints::createInfoString()
@@ -164,7 +164,7 @@ PetscErrorCode SingleBodyPoints::createInfoString()
     ierr = MPI_Barrier(comm); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createInfoString
 
 
 PetscErrorCode SingleBodyPoints::findProc(const PetscInt &i, PetscMPIInt &p) const
@@ -181,7 +181,7 @@ PetscErrorCode SingleBodyPoints::findProc(const PetscInt &i, PetscMPIInt &p) con
             offsetsAllProcs.end(), i*dim) - offsetsAllProcs.begin() - 1;
 
     PetscFunctionReturn(0);
-}
+} // findProc
 
 
 PetscErrorCode SingleBodyPoints::getGlobalIndex(
@@ -202,7 +202,7 @@ PetscErrorCode SingleBodyPoints::getGlobalIndex(
     idx = i * dim + dof;
     
     PetscFunctionReturn(0);
-}
+} // getGlobalIndex
 
 
 PetscErrorCode SingleBodyPoints::getGlobalIndex(
@@ -215,7 +215,7 @@ PetscErrorCode SingleBodyPoints::getGlobalIndex(
     ierr = getGlobalIndex(s.i, s.c, idx); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // getGlobalIndex
 
 
 PetscErrorCode SingleBodyPoints::calculateAvgForces(
@@ -246,7 +246,7 @@ PetscErrorCode SingleBodyPoints::calculateAvgForces(
     ierr = DMDAVecRestoreArrayDOF(da, f, &fArry); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // calculateAvgForces
 
 } // end of namespace body
 } // end of namespace petibm

--- a/src/boundary/boundary.cpp
+++ b/src/boundary/boundary.cpp
@@ -1,7 +1,7 @@
 /**
  * \file boundary.cpp
  * \brief Implementation of boundary::BoundaryBase, type::Boundary, and factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -28,7 +28,7 @@ BoundaryBase::~BoundaryBase()
     if (finalized) return;
 
     comm = MPI_COMM_NULL;
-}
+} // ~BoundaryBase
 
 
 PetscErrorCode BoundaryBase::destroy()
@@ -42,7 +42,7 @@ PetscErrorCode BoundaryBase::destroy()
     mesh.reset();
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 PetscErrorCode createBoundary(
         const type::Mesh &mesh, const YAML::Node &node,
@@ -53,7 +53,7 @@ PetscErrorCode createBoundary(
     boundary = std::make_shared<BoundarySimple>(mesh, node);
     
     PetscFunctionReturn(0);
-}
+} // createBoundary
 
-}
-}
+} // end of namespace boundary
+} // end of namespace petibm

--- a/src/boundary/boundarysimple.cpp
+++ b/src/boundary/boundarysimple.cpp
@@ -1,7 +1,7 @@
 /**
  * \file boundarysimple.cpp
  * \brief Implementation of boundary::BoundarySimple
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -24,7 +24,7 @@ using namespace type;
 BoundarySimple::BoundarySimple(const type::Mesh &inMesh, const YAML::Node &node)
 {
     init(inMesh, node);
-}
+} // BoundarySimple
 
 
 // underlying initialization function
@@ -67,10 +67,10 @@ PetscErrorCode BoundarySimple::init(
     }
 
     PetscFunctionReturn(0);
-}
+} // init
 
 
-// set intial values to ghost points
+// set initial values to ghost points
 PetscErrorCode BoundarySimple::setGhostICs(const type::Solution &soln)
 {
     PetscFunctionBeginUser;
@@ -88,7 +88,7 @@ PetscErrorCode BoundarySimple::setGhostICs(const type::Solution &soln)
     ierr = MPI_Barrier(comm); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // setGhostICs
 
 
 // update the equations between boundary and ghost points
@@ -110,7 +110,7 @@ PetscErrorCode BoundarySimple::updateEqs(
     ierr = MPI_Barrier(comm); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // updateEqs
 
 
 // update values of ghost points
@@ -131,7 +131,7 @@ PetscErrorCode BoundarySimple::updateGhostValues(const type::Solution &soln)
     ierr = MPI_Barrier(comm); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // updateGhostValues
 
 
 // copy values of ghost points to local PETSc Vecs
@@ -152,7 +152,7 @@ PetscErrorCode BoundarySimple::copyValues2LocalVecs(std::vector<Vec> &lclVecs) c
     ierr = MPI_Barrier(comm); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // copyValues2LocalVecs
 
 } // end of namespace boundary
 } // end of namespace petibm

--- a/src/boundary/singleboundary.cpp
+++ b/src/boundary/singleboundary.cpp
@@ -1,7 +1,7 @@
 /**
  * \file singleboundary.cpp
  * \brief Implementation of the function `createSingleBoundary`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -53,7 +53,7 @@ PetscErrorCode createSingleBoundary(
     }
     
     PetscFunctionReturn(0);
-}
+} // createSingleBoundary
 
 } // end of namespace boundary
 } // end of namespace petibm

--- a/src/boundary/singleboundarybase.cpp
+++ b/src/boundary/singleboundarybase.cpp
@@ -1,7 +1,7 @@
 /**
  * \file singleboundarybase.cpp
  * \brief Implementation of the class `SingleBoundaryBase`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -22,7 +22,7 @@ SingleBoundaryBase::SingleBoundaryBase(const type::Mesh &inMesh,
         const type::BCType &inType, const PetscReal &inValue)
 {
     init(inMesh, bcLoc, inField, inType, inValue);
-}
+} // SingleBoundaryBase
 
 
 SingleBoundaryBase::~SingleBoundaryBase()
@@ -35,7 +35,7 @@ SingleBoundaryBase::~SingleBoundaryBase()
     if (finalized) return;
 
     comm = MPI_COMM_NULL;
-}
+} // ~SingleBoundaryBase
 
 
 PetscErrorCode SingleBoundaryBase::destroy()
@@ -54,7 +54,7 @@ PetscErrorCode SingleBoundaryBase::destroy()
     mesh.reset();
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 
 PetscErrorCode SingleBoundaryBase::init(const type::Mesh &inMesh,
@@ -104,7 +104,7 @@ PetscErrorCode SingleBoundaryBase::init(const type::Mesh &inMesh,
     ierr = MPI_Barrier(comm); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // init
 
 
 PetscErrorCode SingleBoundaryBase::setGhostICs(const Vec &vec)
@@ -124,7 +124,7 @@ PetscErrorCode SingleBoundaryBase::setGhostICs(const Vec &vec)
     }
 
     PetscFunctionReturn(0);
-}
+} // setGhostICs
 
 
 PetscErrorCode SingleBoundaryBase::updateEqs(const Vec &vec, const PetscReal &dt)
@@ -144,7 +144,7 @@ PetscErrorCode SingleBoundaryBase::updateEqs(const Vec &vec, const PetscReal &dt
     }
 
     PetscFunctionReturn(0);
-}
+} // updateEqs
 
 
 PetscErrorCode SingleBoundaryBase::updateGhostValues(const Vec &vec)
@@ -164,7 +164,7 @@ PetscErrorCode SingleBoundaryBase::updateGhostValues(const Vec &vec)
     }
 
     PetscFunctionReturn(0);
-}
+} // updateGhostValues
 
 
 PetscErrorCode SingleBoundaryBase::copyValues2LocalVec(Vec &lclVec)
@@ -180,7 +180,7 @@ PetscErrorCode SingleBoundaryBase::copyValues2LocalVec(Vec &lclVec)
     }
 
     PetscFunctionReturn(0);
-}
+} // copyValues2LocalVec
 
 } // end of namespace boundary
 } // end of namespace petibm

--- a/src/boundary/singleboundaryconvective.cpp
+++ b/src/boundary/singleboundaryconvective.cpp
@@ -1,7 +1,7 @@
 /**
  * \file singleboundaryconvective.cpp
  * \brief Implementation of the class `SingleBoundaryConvective`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -22,7 +22,7 @@ PetscErrorCode kernelConvectiveDiffDir(
         2.0 * normal * dt * value * (p.value - targetValue) / p.dL;
     
     PetscFunctionReturn(0);
-}
+} // kernelConvectiveDiffDir
 
 
 PetscErrorCode kernelConvectiveSameDir(
@@ -36,7 +36,7 @@ PetscErrorCode kernelConvectiveSameDir(
     p.a1 = p.value - normal * dt * value * (p.value - targetValue) / p.dL;
     
     PetscFunctionReturn(0);
-}
+} // kernelConvectiveSameDir
 
 
 namespace petibm
@@ -56,7 +56,7 @@ SingleBoundaryConvective::SingleBoundaryConvective(
         kernel = &kernelConvectiveSameDir;
     else
         kernel = &kernelConvectiveDiffDir;
-}
+} // SingleBoundaryConvective
 
 
 PetscErrorCode SingleBoundaryConvective::destroy()
@@ -66,7 +66,7 @@ PetscErrorCode SingleBoundaryConvective::destroy()
     kernel = nullptr;
     ierr = SingleBoundaryBase::destroy(); CHKERRQ(ierr);
     PetscFunctionReturn(0);
-}
+} // destroy
 
 
 PetscErrorCode SingleBoundaryConvective::setGhostICsKernel(
@@ -85,7 +85,7 @@ PetscErrorCode SingleBoundaryConvective::setGhostICsKernel(
     ierr = kernel(targetValue, 0.0, normal, value, p); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // setGhostICsKernel
 
 
 PetscErrorCode SingleBoundaryConvective::updateEqsKernel(const PetscReal &targetValue,
@@ -98,8 +98,7 @@ PetscErrorCode SingleBoundaryConvective::updateEqsKernel(const PetscReal &target
     ierr = kernel(targetValue, dt, normal, value, p); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // updateEqsKernel
 
-
-}
-}
+} // end of namespace boundary
+} // end of namespace petibm

--- a/src/boundary/singleboundarydirichlet.cpp
+++ b/src/boundary/singleboundarydirichlet.cpp
@@ -1,7 +1,7 @@
 /**
  * \file singleboundarydirichlet.cpp
  * \brief Implementation of the class `SingleBoundaryDirichlet`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -19,7 +19,10 @@ namespace boundary
 SingleBoundaryDirichlet::SingleBoundaryDirichlet(
         const type::Mesh &inMesh, const type::BCLoc &inLoc,
         const type::Field &inField, const PetscReal &inValue):
-    SingleBoundaryBase(inMesh, inLoc, inField, type::DIRICHLET, inValue) {}
+    SingleBoundaryBase(inMesh, inLoc, inField, type::DIRICHLET, inValue)
+{
+
+} // SingleBoundaryDirichlet
 
 
 PetscErrorCode SingleBoundaryDirichlet::setGhostICsKernel(
@@ -31,7 +34,7 @@ PetscErrorCode SingleBoundaryDirichlet::setGhostICsKernel(
     
     // bad idea; this means every ghost point, p, passed in will need to go
     // through this if-condition, even though they all have same dir and field
-    // Luckly, for time-independent Dirichlet BC, a0 & a1 won't change afterward
+    // Luckily, for time-independent Dirichlet BC, a0 & a1 won't change afterward
     if (dir == int(field))
     {    
         p.a0 = 0.0;
@@ -46,7 +49,7 @@ PetscErrorCode SingleBoundaryDirichlet::setGhostICsKernel(
     p.value = p.a0 * targetValue + p.a1;
     
     PetscFunctionReturn(0);
-}
+} // setGhostICsKernel
 
 
 PetscErrorCode SingleBoundaryDirichlet::updateEqsKernel(const PetscReal &targetValue,
@@ -55,8 +58,7 @@ PetscErrorCode SingleBoundaryDirichlet::updateEqsKernel(const PetscReal &targetV
     PetscFunctionBeginUser;
     // for time-independent Dirichlet BC, the coefficient a0 & a1 won't change
     PetscFunctionReturn(0);
-}
+} // updateEqsKernel
 
-
-}
-}
+} // end of namespace boundary
+} // end of namespace petibm

--- a/src/boundary/singleboundaryneumann.cpp
+++ b/src/boundary/singleboundaryneumann.cpp
@@ -1,7 +1,7 @@
 /**
  * \file singleboundaryneumann.cpp
  * \brief Implementation of the class `SingleBoundaryNeumann`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -19,7 +19,10 @@ namespace boundary
 SingleBoundaryNeumann::SingleBoundaryNeumann(
         const type::Mesh &inMesh, const type::BCLoc &inLoc,
         const type::Field &inField, const PetscReal &inValue):
-    SingleBoundaryBase(inMesh, inLoc, inField, type::NEUMANN, inValue) {}
+    SingleBoundaryBase(inMesh, inLoc, inField, type::NEUMANN, inValue)
+{
+
+} // SingleBoundaryNeumann
 
 
 PetscErrorCode SingleBoundaryNeumann::setGhostICsKernel(
@@ -33,7 +36,7 @@ PetscErrorCode SingleBoundaryNeumann::setGhostICsKernel(
     p.value = p.a0 * targetValue + p.a1;
     
     PetscFunctionReturn(0);
-}
+} // setGhostICsKernel
 
 
 PetscErrorCode SingleBoundaryNeumann::updateEqsKernel(const PetscReal &targetValue,
@@ -42,8 +45,7 @@ PetscErrorCode SingleBoundaryNeumann::updateEqsKernel(const PetscReal &targetVal
     PetscFunctionBeginUser;
     // for time-independent Neumann BC, the coefficient a0 & a1 won't change
     PetscFunctionReturn(0);
-}
+} // updateEqsKernel
 
-
-}
-}
+} // end of namespace boundary
+} // end of namespace petibm

--- a/src/boundary/singleboundaryperiodic.cpp
+++ b/src/boundary/singleboundaryperiodic.cpp
@@ -1,7 +1,7 @@
 /**
  * \file singleboundaryperiodic.cpp
  * \brief Implementation of the class `SingleBoundaryPeriodic`.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -49,7 +49,7 @@ SingleBoundaryPeriodic::SingleBoundaryPeriodic(
     
     // set normal
     normal = ((int(loc)%2) == 0) ? -1.0 : 1.0;
-}
+} // SingleBoundaryPeriodic
 
 
 PetscErrorCode SingleBoundaryPeriodic::setGhostICsKernel(
@@ -58,7 +58,7 @@ PetscErrorCode SingleBoundaryPeriodic::setGhostICsKernel(
     PetscFunctionBeginUser;
     // for Periodic BC, do nothing. Let PETSc handle that. 
     PetscFunctionReturn(0);
-}
+} // setGhostICsKernel
 
 
 PetscErrorCode SingleBoundaryPeriodic::updateEqsKernel(const PetscReal &targetValue,
@@ -67,8 +67,8 @@ PetscErrorCode SingleBoundaryPeriodic::updateEqsKernel(const PetscReal &targetVa
     PetscFunctionBeginUser;
     // for Periodic BC, do nothing. Let PETSc handle that. 
     PetscFunctionReturn(0);
-}
+} // updateEqsKernel
 
 
-}
-}
+} // end of namespace boundary
+} // end of namespace petibm

--- a/src/io/io.cpp
+++ b/src/io/io.cpp
@@ -1,7 +1,7 @@
 /**
  * \file io.cpp
  * \brief Implementations of I/O functions.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -80,7 +80,7 @@ PetscErrorCode readLagrangianPoints(const std::string &file,
         sline.clear();
         for(PetscInt d=0; d<dim; ++d) sline >> coords[0][d];
         
-        // increade c
+        // increase c
         c += 1;
     }
 
@@ -114,7 +114,7 @@ PetscErrorCode readLagrangianPoints(const std::string &file,
                 file.c_str());
 
     PetscFunctionReturn(0);
-}
+} // readLagrangianPoints
 
 
 PetscErrorCode print(const std::string &info)
@@ -131,7 +131,7 @@ PetscErrorCode print(const std::string &info)
     ierr = PetscPrintf(PETSC_COMM_WORLD, "\n"); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // print
 
 
 PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file, 
@@ -163,7 +163,7 @@ PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file,
     ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // writeHDF5Vecs
 
 
 PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file,
@@ -199,7 +199,7 @@ PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file,
     ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // writeHDF5Vecs
 
 
 PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file,
@@ -234,7 +234,7 @@ PetscErrorCode writeHDF5Vecs(const MPI_Comm comm, const std::string &file,
     ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // writeHDF5Vecs
 
 
 PetscErrorCode readHDF5Vecs(const MPI_Comm comm, const std::string &file,
@@ -266,7 +266,7 @@ PetscErrorCode readHDF5Vecs(const MPI_Comm comm, const std::string &file,
     ierr = PetscViewerDestroy(&viewer); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // readHDF5Vecs
 
 } // end of namespace io
-} // petibm
+} // end of namespace petibm

--- a/src/linsolver/linsolver.cpp
+++ b/src/linsolver/linsolver.cpp
@@ -27,7 +27,7 @@ PetscErrorCode LinSolverBase::destroy()
     PetscFunctionBeginUser;
     name = config = type = "";
     PetscFunctionReturn(0);
-}
+} // destroy
     
     
 // implement LinSolverBase::printInfo
@@ -48,7 +48,7 @@ PetscErrorCode LinSolverBase::printInfo() const
     ierr = PetscPrintf(PETSC_COMM_WORLD, "%s", info.c_str()); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // printInfo
 
 
 // implement LinSolverBase::getType
@@ -57,7 +57,7 @@ PetscErrorCode LinSolverBase::getType(std::string &_type) const
     PetscFunctionBeginUser;
     _type = type;
     PetscFunctionReturn(0);
-}
+} // getType
 
 
 // implement petibm::linsolver::createLinSolver
@@ -113,7 +113,7 @@ PetscErrorCode createLinSolver(const std::string &solverName,
                 "\"%s\"\n", type.c_str(), solverName.c_str());
 
     PetscFunctionReturn(0);
-}
+} // createLinSolver
 
 } // end of namespace linsolver
 } // end of namespace petibm

--- a/src/linsolver/linsolveramgx.cpp
+++ b/src/linsolver/linsolveramgx.cpp
@@ -24,7 +24,7 @@ PetscErrorCode preDestroyAmgXSolvers()
         ierr = it->finalize(); CHKERRQ(ierr);
     }
     PetscFunctionReturn(0);
-}
+} // preDestroyAmgXSolvers
 
 namespace petibm
 {
@@ -34,7 +34,10 @@ namespace linsolver
 // implement LinSolverAmgX::LinSolverAmgX
 LinSolverAmgX::LinSolverAmgX(
         const std::string &solverName, const std::string &file):
-    LinSolverBase(solverName, file) { init(); }
+    LinSolverBase(solverName, file)
+{
+	init();
+} // LinSolverAmgX
 
 
 // implement LinSolverAmgX::~LinSolverAmgX
@@ -48,7 +51,7 @@ LinSolverAmgX::~LinSolverAmgX()
     if (finalized) return;
 
     ierr = amgx.finalize(); CHKERRV(ierr);
-}
+} // ~LinSolverAmgX
 
 
 // implement LinSolverAmgX::destroy
@@ -62,7 +65,7 @@ PetscErrorCode LinSolverAmgX::destroy()
     ierr = LinSolverBase::destroy(); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 
 // implement LinSolverAmgX::init
@@ -80,7 +83,7 @@ PetscErrorCode LinSolverAmgX::init()
     ierr = PetscRegisterFinalize(&preDestroyAmgXSolvers); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // init
 
 
 // implement LinSolverAmgX::setMatrix

--- a/src/linsolver/linsolverksp.cpp
+++ b/src/linsolver/linsolverksp.cpp
@@ -18,7 +18,10 @@ namespace linsolver
 
 // implement LinSolverKSP::LinSolverKSP
 LinSolverKSP::LinSolverKSP(const std::string &_name, const std::string &_config):
-    LinSolverBase(_name, _config) { init(); }
+    LinSolverBase(_name, _config)
+{
+	init();
+} // LinSolverKSP
 
 
 // implement LinSolverKSP::~LinSolverKSP
@@ -33,7 +36,7 @@ LinSolverKSP::~LinSolverKSP()
     if (finalized) return;
 
     ierr = KSPDestroy(&ksp); CHKERRV(ierr);
-}
+} // ~LinSolverKSP
 
 
 // implement LinSolverKSP::destroy
@@ -45,7 +48,7 @@ PetscErrorCode LinSolverKSP::destroy()
     ierr = LinSolverBase::destroy(); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 
 // implement LinSolverKSP::init
@@ -67,7 +70,7 @@ PetscErrorCode LinSolverKSP::init()
     ierr = KSPSetFromOptions(ksp); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // init
 
 
 // implement LinSolverKSP::setMatrix

--- a/src/mesh/cartesianmesh.cpp
+++ b/src/mesh/cartesianmesh.cpp
@@ -1,7 +1,7 @@
 /**
  * \file cartesianmesh.cpp
  * \brief Implementations of mesh::CartesianMesh.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -36,7 +36,7 @@ using namespace type;
 CartesianMesh::CartesianMesh(const MPI_Comm &world, const YAML::Node &node)
 {
     init(world, node);
-}
+} // CartesianMesh
 
 
 // implementation of CartesianMesh::~CastesianMesh
@@ -51,7 +51,7 @@ CartesianMesh::~CartesianMesh()
     if (finalized) return;
 
     std::vector<AO>().swap(ao); // DO NOT DESTROY UNDERLYING AOs!!
-}
+} // ~CartesianMesh
 
 
 // implementation of CartesianMesh::destroy
@@ -71,7 +71,7 @@ PetscErrorCode CartesianMesh::destroy()
     ierr = MeshBase::destroy(); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 
 // implementation of CartesianMesh::init
@@ -93,7 +93,7 @@ PetscErrorCode CartesianMesh::init(const MPI_Comm &world, const YAML::Node &node
     // set the default sizes and values for members
     // The default values are chosen for 2D cases. We want to eliminate the use
     // of template and also `if` conditions that determine the dimension. So
-    // with carefully choosed default values, we can take care of 2D case with 
+    // with carefully chosen default values, we can take care of 2D case with 
     // 3D code in many places.
     min = RealVec1D(3, 0.0);
     max = RealVec1D(3, 1.0);
@@ -138,12 +138,12 @@ PetscErrorCode CartesianMesh::init(const MPI_Comm &world, const YAML::Node &node
     // create a std::string that can be used in `printInfo` and output stream
     ierr = createInfoString(); CHKERRQ(ierr);
 
-    // all processes should be syncrinized
+    // all processes should be synchronized
     ierr = MPI_Barrier(comm); CHKERRQ(ierr);
 
 
     PetscFunctionReturn(0);
-}
+} // init
 
 
 // implementation of CartesianMesh::createPressureMesh
@@ -176,7 +176,7 @@ PetscErrorCode CartesianMesh::createPressureMesh()
     // total number of pressure points
     pN = n[3][0] * n[3][1] * n[3][2];   // for 2D, n[3][2] should be 1
 
-    // in 2D simulation, we still use the varaible dL in z-direction
+    // in 2D simulation, we still use the variable dL in z-direction
     if (dim == 2)
     {
         dL[3][2] = &dLTrue[3][2][0];
@@ -184,7 +184,7 @@ PetscErrorCode CartesianMesh::createPressureMesh()
     }
 
     PetscFunctionReturn(0);
-}
+} // createPressureMesh
 
 
 // implementation of CartesianMesh::createVertexMesh
@@ -204,7 +204,7 @@ PetscErrorCode CartesianMesh::createVertexMesh()
         std::partial_sum(dLTrue[3][i].begin(), dLTrue[3][i].end(), 
                 coordTrue[4][i].begin()+1); // first assume coord[4][i][0]=0.0
 
-        // shift aacording to real coord[4][i][0], which is min
+        // shift according to real coord[4][i][0], which is min
         std::for_each(coordTrue[4][i].begin(), coordTrue[4][i].end(),
                 [i, this] (double &a) -> void { a += this->min[i]; });
 
@@ -212,11 +212,11 @@ PetscErrorCode CartesianMesh::createVertexMesh()
         coord[4][i] = &coordTrue[4][i][0];
     }
 
-    // in 2D simulation, we still use the varaible coord in z-direction
+    // in 2D simulation, we still use the variable coord in z-direction
     if (dim == 2) coord[4][2] = &coordTrue[4][2][0];
 
     PetscFunctionReturn(0);
-}
+} // createVertexMesh
 
 
 // implementation of CartesianMesh::createCelocityMesh
@@ -300,7 +300,7 @@ PetscErrorCode CartesianMesh::createVelocityMesh()
                 dLTrue[comp][dir].resize(n[comp][dir]+2);
                 coordTrue[comp][dir].resize(n[comp][dir]+2);
 
-                // coordinate and cel size will match that of pressure point,
+                // coordinate and cell size will match that of pressure point,
                 // except the two ghost points
                 std::copy(coordTrue[3][dir].begin(), coordTrue[3][dir].end(),
                         coordTrue[comp][dir].begin()+1);
@@ -360,7 +360,7 @@ PetscErrorCode CartesianMesh::createVelocityMesh()
     }
 
     PetscFunctionReturn(0);
-}
+} // createVelocityMesh
 
 
 // implementation of CartesianMesh::createInfoString
@@ -417,7 +417,7 @@ PetscErrorCode CartesianMesh::createInfoString()
     info = ss.str();
 
     PetscFunctionReturn(0);
-}
+} // createInfoString
 
 
 // implementation of CartesianMesh::addLocalInfoString
@@ -444,7 +444,7 @@ PetscErrorCode CartesianMesh::addLocalInfoString(std::stringstream &ss)
     }
 
     PetscFunctionReturn(0);
-}
+} // addLocalInfoString
 
 
 // implementation of CartesianMesh::initDMDA
@@ -499,7 +499,7 @@ PetscErrorCode CartesianMesh::initDMDA()
     pNLocal = m[3][0] * m[3][1] * m[3][2];
 
     PetscFunctionReturn(0);
-}
+} // initDMDA
 
 
 // implementation of CartesianMesh::createSingleDMDA
@@ -547,7 +547,7 @@ PetscErrorCode CartesianMesh::createSingleDMDA(const PetscInt &i)
         ed[i][comp] = bg[i][comp] + m[i][comp];
 
     PetscFunctionReturn(0);
-}
+} // createSingleDMDA
 
 
 // implementation of CartesianMesh::createPressureDMDA
@@ -568,7 +568,7 @@ PetscErrorCode CartesianMesh::createPressureDMDA()
            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createPressureDMDA
 
 
 // implementation of CartesianMesh::createVelocityPack
@@ -590,7 +590,7 @@ PetscErrorCode CartesianMesh::createVelocityPack()
     }
 
     PetscFunctionReturn(0);
-}
+} // createVelocityPack
 
 
 // implementation of CartesianMesh::getNaturalIndex
@@ -604,7 +604,7 @@ PetscErrorCode CartesianMesh::getNaturalIndex(
     ierr = getNaturalIndex(f, s.i, s.j, s.k, idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getNaturalIndex
 
 
 // implementation of CartesianMesh::getNaturalIndex
@@ -688,7 +688,7 @@ PetscErrorCode CartesianMesh::getNaturalIndex(const PetscInt &f,
     idx = i + j * n[f][0] + ((dim == 3) ? (k * n[f][1] * n[f][0]) : 0);
 
     PetscFunctionReturn(0);
-}
+} // getNaturalIndex
 
 
 // implementation of CartesianMesh::getLocalIndex
@@ -702,7 +702,7 @@ PetscErrorCode CartesianMesh::getLocalIndex(
     ierr = DMDAConvertToCell(da[f], s, &idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getLocalIndex
 
 
 // implementation of CartesianMesh::getLocalIndex
@@ -717,7 +717,7 @@ PetscErrorCode CartesianMesh::getLocalIndex(const PetscInt &f,
     ierr = getLocalIndex(f, {k, j, i, 0}, idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getLocalIndex
 
 
 // implementation of CartesianMesh::getGlobalIndex
@@ -732,7 +732,7 @@ PetscErrorCode CartesianMesh::getGlobalIndex(
     ierr = AOApplicationToPetsc(ao[f], 1, &idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getGlobalIndex
 
 
 // implementation of CartesianMesh::getGlobalIndex
@@ -747,7 +747,7 @@ PetscErrorCode CartesianMesh::getGlobalIndex(const PetscInt &f,
     ierr = getGlobalIndex(f, {k, j, i, 0}, idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getGlobalIndex
 
 
 // implementation of CartesianMesh::getPackedGlobalIndex
@@ -777,7 +777,7 @@ PetscErrorCode CartesianMesh::getPackedGlobalIndex(
     p = std::upper_bound(offsetsAllProcs[f].begin(), offsetsAllProcs[f].end(), 
             unPackedIdx) - offsetsAllProcs[f].begin() - 1;
 
-    // the beginngin index of process p in packed DM
+    // the beginning index of process p in packed DM
     idx = offsetsPackAllProcs[p]; 
 
     // offset due to previous DMs
@@ -787,7 +787,7 @@ PetscErrorCode CartesianMesh::getPackedGlobalIndex(
     idx += (unPackedIdx - offsetsAllProcs[f][p]);
 
     PetscFunctionReturn(0);
-}
+} // getPackedGlobalIndex
 
 
 // implementation of CartesianMesh::getPackedGlobalIndex
@@ -802,7 +802,7 @@ PetscErrorCode CartesianMesh::getPackedGlobalIndex(const PetscInt &f,
     ierr = getPackedGlobalIndex(f, {k, j, i, 0}, idx); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getPackedGlobalIndex
 
 
 // implementation of CartesianMesh::write
@@ -831,7 +831,7 @@ PetscErrorCode CartesianMesh::write(const std::string &filePath) const
     ierr = MPI_Barrier(comm); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // write
 
 } // end of namespace mesh
 } // end of namespace petibm

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1,7 +1,7 @@
 /**
  * \file mesh.cpp
  * \brief Implementations of mesh::MeshBase and factory function.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -36,7 +36,7 @@ MeshBase::~MeshBase()
     ierr = DMDestroy(&da[4]); CHKERRV(ierr);
     ierr = DMDestroy(&UPack); CHKERRV(ierr);
     comm = MPI_COMM_NULL;
-}
+} // ~MeshBase
 
 // implement MeshBase::destroy
 PetscErrorCode MeshBase::destroy()
@@ -73,7 +73,7 @@ PetscErrorCode MeshBase::destroy()
     mpiSize = mpiRank = 0;
 
     PetscFunctionReturn(0);
-}
+} // destroy
 
 // implement MeshBase::printInfo
 PetscErrorCode MeshBase::printInfo() const
@@ -84,7 +84,7 @@ PetscErrorCode MeshBase::printInfo() const
     ierr = io::print(info); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // printInfo
     
 // implement petibm::mesh::createMesh
 PetscErrorCode createMesh(const MPI_Comm &comm,
@@ -95,7 +95,7 @@ PetscErrorCode createMesh(const MPI_Comm &comm,
     mesh = std::make_shared<CartesianMesh>(comm, node);
 
     PetscFunctionReturn(0);
-}
+} // createMesh
 
 } // end of mesh
 } // end of petibm

--- a/src/misc/delta.cpp
+++ b/src/misc/delta.cpp
@@ -1,7 +1,7 @@
 /**
  * \file delta.cpp
  * \brief Implementations of descritized delta functions.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.

--- a/src/misc/misc.cpp
+++ b/src/misc/misc.cpp
@@ -1,7 +1,7 @@
 /**
  * \file misc.cpp
  * \brief Implementations of some miscellaneous functions.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -79,7 +79,7 @@ namespace misc
         }
 
         PetscFunctionReturn(0);
-    }
+    } // checkPeriodicBC
     
 
     PetscErrorCode checkBoundaryProc(const DM &da, const type::IntVec1D &n,
@@ -124,7 +124,7 @@ namespace misc
         else
             onThisProc = PETSC_FALSE;
             PetscFunctionReturn(0);
-        }
+        } // checkBoundaryProc
 
 
     PetscErrorCode getGhostPointList(const type::Mesh &mesh,
@@ -193,7 +193,7 @@ namespace misc
         }
 
         PetscFunctionReturn(0);
-    }
+    } // getGhostPointList
     
 
     PetscErrorCode getPerpendAxes(const PetscInt &self, type::IntVec1D &pAxes)
@@ -220,7 +220,7 @@ namespace misc
         }
         
         PetscFunctionReturn(0);
-    }
+    } // getPerpendAxes
     
 
     PetscErrorCode getGhostTargetStencil(const type::IntVec1D &n,
@@ -262,6 +262,7 @@ namespace misc
         }
         
         PetscFunctionReturn(0);
-    }
-}
-}
+    } // getGhostTargetStencil
+
+} // end of namespace misc
+} // end of namespace petibm

--- a/src/misc/type.cpp
+++ b/src/misc/type.cpp
@@ -26,7 +26,7 @@ bool operator<(const MatStencil &l, const MatStencil &r)
     if (l.c < r.c) return true;
 
     return false;
-}
+} // operator<
 
 
 namespace petibm

--- a/src/operators/createbn.cpp
+++ b/src/operators/createbn.cpp
@@ -1,7 +1,7 @@
 /**
  * \file createbn.cpp
  * \brief Definition of functions for creating approximated inverse A.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -59,7 +59,7 @@ PetscErrorCode createBnHead(const Mat &Op, const PetscReal &dt,
     // calculate the matrix for each term if order > 1, and add back to BnHead
     for(PetscInt term=2; term<=n; ++term)
     {
-        // the most right matrix of seccessive mat-mat-multiplication
+        // the most right matrix of successive mat-mat-multiplication
         ierr = MatDuplicate(Op, MAT_COPY_VALUES, &rightMat); CHKERRQ(ierr);
 
         // successive mat-mat-multiplications
@@ -93,7 +93,7 @@ PetscErrorCode createBnHead(const Mat &Op, const PetscReal &dt,
     }
 
     PetscFunctionReturn(0);
-}
+} // createBnHead
 
 
 // implementation of createBn
@@ -127,7 +127,7 @@ PetscErrorCode createBn(const Mat &Op, const Mat &R, const Mat &MHead,
     ierr = VecDestroy(&MHeadDiagInv); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createBn
 
 
 // implementation of createBn
@@ -177,7 +177,7 @@ PetscErrorCode createBn(const Mat &Op, const Mat &M, const PetscReal &dt,
 
     for(PetscInt term=2; term<=n; ++term)
     {
-        // the most right matrix of seccessive mat-mat-multiplication
+        // the most right matrix of successive mat-mat-multiplication
         ierr = MatDuplicate(leftMat, MAT_COPY_VALUES, &rightMat); CHKERRQ(ierr);
 
         // successive mat-mat-multiplications
@@ -217,7 +217,7 @@ PetscErrorCode createBn(const Mat &Op, const Mat &M, const PetscReal &dt,
     ierr = MatDestroy(&leftMat); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createBn
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/operators/createconvection.cpp
+++ b/src/operators/createconvection.cpp
@@ -1,7 +1,7 @@
 /**
  * \file createconvection.cpp
  * \brief Definition of functions creating convection operator.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -121,7 +121,7 @@ PetscErrorCode createConvection(const type::Mesh &mesh,
         ierr = MatShellSetOperation(H, MATOP_MULT, 
                 (void(*)(void)) ConvectionMult2D); CHKERRQ(ierr);
     }
-    else // assuem the dim is either 2 or 3
+    else // assume the dim is either 2 or 3
     {
         ierr = MatShellSetOperation(H, MATOP_MULT, 
                 (void(*)(void)) ConvectionMult3D); CHKERRQ(ierr);
@@ -132,7 +132,7 @@ PetscErrorCode createConvection(const type::Mesh &mesh,
             (void(*)(void)) ConvectionDestroy); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createConvection
 
 
 // implementation of ConvectionMult2D
@@ -205,7 +205,7 @@ PetscErrorCode ConvectionMult2D(Mat mat, Vec x, Vec y)
             y, ctx->mesh->dim, nullptr, unPacked.data()); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // ConvectionMult2D
 
 
 // implementation of ConvectionMult3D
@@ -288,7 +288,7 @@ PetscErrorCode ConvectionMult3D(Mat mat, Vec x, Vec y)
 
 
     PetscFunctionReturn(0);
-}
+} // ConvectionMult3D
 
 
 // implementation of ConvectionDestroy
@@ -313,7 +313,7 @@ PetscErrorCode ConvectionDestroy(Mat mat)
     delete ctx;
 
     PetscFunctionReturn(0);
-}
+} // ConvectionDestroy
 
 
 // implementation of kernelU in 2D
@@ -341,7 +341,7 @@ inline PetscReal kernelU(
     return 
         (uE * uE - uW * uW) / ctx->mesh->dL[0][0][i] + 
         (vN * uN - vS * uS) / ctx->mesh->dL[0][1][j];
-}
+} // kernelU
 
 
 // implementation of kernelV in 2D
@@ -369,7 +369,7 @@ inline PetscReal kernelV(
     return 
         (uE * vE - uW * vW) / ctx->mesh->dL[1][0][i] +
         (vN * vN - vS * vS) / ctx->mesh->dL[1][1][j];
-}
+} // kernelV
 
 
 // implementation of kernelU in 3D
@@ -405,7 +405,7 @@ inline PetscReal kernelU(
         (uE * uE - uW * uW) / ctx->mesh->dL[0][0][i] + 
         (vN * uN - vS * uS) / ctx->mesh->dL[0][1][j] + 
         (wF * uF - wB * uB) / ctx->mesh->dL[0][2][k];
-}
+} // kernelU
 
 
 // implementation of kernelV in 3D
@@ -442,7 +442,7 @@ inline PetscReal kernelV(
         (vN * vN - vS * vS) / ctx->mesh->dL[1][1][j] +
         (wF * vF - wB * vB) / ctx->mesh->dL[1][2][k];
 
-}
+} // kernelV
 
 
 // implementation of kernelW in 3D
@@ -478,7 +478,7 @@ inline PetscReal kernelW(
         (uE * wE - uW * wW) / ctx->mesh->dL[2][0][i] +
         (vN * wN - vS * wS) / ctx->mesh->dL[2][1][j] +
         (wF * wF - wB * wB) / ctx->mesh->dL[2][2][k];
-}
+} // kernelW
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/operators/createdelta.cpp
+++ b/src/operators/createdelta.cpp
@@ -1,7 +1,7 @@
 /**
  * \file createdelta.cpp
  * \brief Definition of functions creating Delta operator.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -25,7 +25,7 @@ namespace petibm
 namespace operators
 {
 
-// TODO: it's anti-readiable that we mix the use of local and global Lagrangian index
+// TODO: it's anti-readable that we mix the use of local and global Lagrangian index
 // TODO: no pre-allocation for D matrix, this may be inefficient, though it works
 
 
@@ -174,7 +174,7 @@ PetscErrorCode createDelta(const type::Mesh &mesh, const type::Boundary &bc,
     ierr = MatAssemblyEnd(D, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createDelta
 
 
 PetscErrorCode getWindowAndDistance(const PetscInt &dim,
@@ -222,7 +222,7 @@ PetscErrorCode getWindowAndDistance(const PetscInt &dim,
     }
 
     PetscFunctionReturn(0);
-}
+} // getWindowAndDistance
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/operators/creatediagmatrix.cpp
+++ b/src/operators/creatediagmatrix.cpp
@@ -1,7 +1,7 @@
 /**
  * \file creatediagmatrix.cpp
  * \brief Definitions of functions creating different kinds of diagonal matrices.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -88,7 +88,7 @@ PetscErrorCode createDiagMatrix(const type::Mesh &mesh,
     ierr = MatAssemblyEnd(M, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createDiagMatrix
 
 
 // implementation of petibm::operators::createR
@@ -113,7 +113,7 @@ PetscErrorCode createR(const type::Mesh &mesh, Mat &R)
     ierr = createDiagMatrix(mesh, kernel, R); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createR
 
 
 // implementation of petibm::operators::createRInv
@@ -138,7 +138,7 @@ PetscErrorCode createRInv(const type::Mesh &mesh, Mat &RInv)
     ierr = createDiagMatrix(mesh, kernel, RInv); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createRInv
 
 
 // implementation of petibm::operators::createMHead
@@ -163,7 +163,7 @@ PetscErrorCode createMHead(const type::Mesh &mesh, Mat &MHead)
     ierr = createDiagMatrix(mesh, kernel, MHead); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createMHead
 
 
 // implementation of petibm::operators::createM
@@ -188,7 +188,7 @@ PetscErrorCode createM(const type::Mesh &mesh, Mat &M)
     ierr = createDiagMatrix(mesh, kernel, M); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createM
 
 
 // implementation of petibm::operators::createIdentity
@@ -213,7 +213,7 @@ PetscErrorCode createIdentity(const type::Mesh &mesh, Mat &I)
     ierr = createDiagMatrix(mesh, kernel, I); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createIdentity
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/operators/createdivergence.cpp
+++ b/src/operators/createdivergence.cpp
@@ -1,7 +1,7 @@
 /**
  * \file createdivergence.cpp
  * \brief Definition of functions creating divergence operator.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -188,7 +188,7 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
                 }
 
 
-    // assemble matrix, an implicit mpi barrier is applied
+    // assemble matrix, an implicit MPI barrier is applied
     ierr = MatAssemblyBegin(D, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
     ierr = MatAssemblyEnd(D, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
 
@@ -205,7 +205,7 @@ PetscErrorCode createDivergence(const type::Mesh &mesh,
             (void(*)(void)) DCorrectionDestroy); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createDivergence
 
 
 // implementation of DCorrectionMult
@@ -235,12 +235,12 @@ PetscErrorCode DCorrectionMult(Mat mat, Vec x, Vec y)
                 }
 
     // assembly (not sure if this is necessary and if this causes overhead)
-    // but there is an implicit MPI barrier in assembly, which we defenitely need
+    // but there is an implicit MPI barrier in assembly, which we definitely need
     ierr = VecAssemblyBegin(y); CHKERRQ(ierr);
     ierr = VecAssemblyEnd(y); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // DCorrectionMult
 
 
 // implementation of DCorrectionDestroy
@@ -258,7 +258,7 @@ PetscErrorCode DCorrectionDestroy(Mat mat)
     delete ctx;
 
     PetscFunctionReturn(0);
-}
+} // DCorrectionDestroy
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/operators/creategradient.cpp
+++ b/src/operators/creategradient.cpp
@@ -1,7 +1,7 @@
 /**
  * \file creategradient.cpp
  * \brief Definition of functions creating gradient operator.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -128,7 +128,7 @@ PetscErrorCode createGradient(const type::Mesh &mesh,
     ierr = MatAssemblyEnd(G, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createGradient
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/operators/createlaplacian.cpp
+++ b/src/operators/createlaplacian.cpp
@@ -1,7 +1,7 @@
 /**
  * \file createlaplacian.cpp
  * \brief Definition of functions creating Laplacian operator.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -62,9 +62,9 @@ typedef std::function<StencilVec(const PetscInt &,
  * \param bc an instance of Boundary class.
  * \param getStencils a function that returns stencils according to dim.
  * \param f the index of field (u=0, v=1, z=2).
- * \param i the x-index of current row in the cartesian mesh.
- * \param j the y-index of current row in the cartesian mesh.
- * \param k the z-index of current row in the cartesian mesh.
+ * \param i the x-index of current row in the Cartesian mesh.
+ * \param j the y-index of current row in the Cartesian mesh.
+ * \param k the z-index of current row in the Cartesian mesh.
  * \param L the Laplacian matrix.
  * \param rowModifiers an object holding information about where in a matrix 
  *                     should be modified.
@@ -165,7 +165,7 @@ PetscErrorCode createLaplacian(const type::Mesh &mesh,
                 }
 
 
-    // assemble matrix, an implicit mpi barrier is applied
+    // assemble matrix, an implicit MPI barrier is applied
     ierr = MatAssemblyBegin(L, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
     ierr = MatAssemblyEnd(L, MAT_FINAL_ASSEMBLY); CHKERRQ(ierr);
 
@@ -182,7 +182,7 @@ PetscErrorCode createLaplacian(const type::Mesh &mesh,
             (void(*)(void)) LCorrectionDestroy); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // createLaplacian
 
 
 // implementation of setRowValues
@@ -214,7 +214,7 @@ inline PetscErrorCode setRowValues(
 
 
     // get the values. One direction each time.
-    // Luckly we have dL for ghost points, and the index of -1 is usable in dL,
+    // Luckily we have dL for ghost points, and the index of -1 is usable in dL,
     // so we don't have to use "if" to find out the boundary points
     for(PetscInt dir=0; dir<mesh->dim; ++dir)
     {
@@ -242,7 +242,7 @@ inline PetscErrorCode setRowValues(
         if (cols[id] == -1) rowModifiers[stencils[id]] = {cols[0], values[id]};
 
     PetscFunctionReturn(0);
-}
+} // setRowValues
 
 
 // implementation of LCorrectionMult
@@ -272,12 +272,12 @@ PetscErrorCode LCorrectionMult(Mat mat, Vec x, Vec y)
                 }
 
     // assembly (not sure if this is necessary and if this causes overhead)
-    // but there is an implicit MPI barrier in assembly, which we defenitely need
+    // but there is an implicit MPI barrier in assembly, which we definitely need
     ierr = VecAssemblyBegin(y); CHKERRQ(ierr);
     ierr = VecAssemblyEnd(y); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // LCorrectionMult
 
 
 // implementation of LCorrectionDestroy
@@ -295,7 +295,7 @@ PetscErrorCode LCorrectionDestroy(Mat mat)
     delete ctx;
 
     PetscFunctionReturn(0);
-}
+} // LCorrectionDestroy
 
 } // end of namespace operators
 } // end of namespace petibm

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -1,7 +1,7 @@
 /**
  * \file parser.cpp
  * \brief Implementations of parser functions.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -31,7 +31,7 @@ namespace petibm
 namespace parser
 {
 
-// get all settings into a sinfle YAML node
+// get all settings into a single YAML node
 PetscErrorCode getSettings(YAML::Node &node)
 {
     PetscFunctionBeginUser;
@@ -52,7 +52,7 @@ PetscErrorCode getSettings(YAML::Node &node)
 
     if (flg) node["directory"] = s;
 
-    // config: location of config.yaml. Default is under worling directory.
+    // config: location of config.yaml. Default is under working directory.
     // TODO: what if users provide a relative path? Where should it relative to?
     node["config.yaml"] = node["directory"].as<std::string>() + "/config.yaml";
 
@@ -100,7 +100,7 @@ PetscErrorCode getSettings(YAML::Node &node)
     ierr = readYAMLs(node); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // getSettings
 
 
 PetscErrorCode parseMesh(const YAML::Node &meshNode, PetscInt &dim,
@@ -136,7 +136,7 @@ PetscErrorCode parseMesh(const YAML::Node &meshNode, PetscInt &dim,
     }
 
     PetscFunctionReturn(0);
-}
+} // parseMesh
 
 
 PetscErrorCode parseOneAxis(const YAML::Node &axis, PetscInt &dir,
@@ -159,7 +159,7 @@ PetscErrorCode parseOneAxis(const YAML::Node &axis, PetscInt &dir,
     ierr = parseSubDomains(axis["subDomains"], bg, nTotal, ed, dL); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // parseOneAxis
 
 
 PetscErrorCode parseSubDomains(const YAML::Node &subs, const PetscReal bg,
@@ -179,24 +179,24 @@ PetscErrorCode parseSubDomains(const YAML::Node &subs, const PetscReal bg,
     // initialize dL
     dL = type::RealVec1D();
 
-    // loop through all subdomains
+    // loop through all sub-domains
     for(auto sub: subs)
     {
-        type::RealVec1D   dLSub;  // cell sizes of the subdomains
-        PetscInt           nSub;  // number of the cells of the subdomains
+        type::RealVec1D   dLSub;  // cell sizes of the sub-domains
+        PetscInt           nSub;  // number of the cells of the sub-domains
 
         // the 1st ed is passed by value, while the 2nd one is by reference
         ierr = parseOneSubDomain(sub, ed, nSub, ed, dLSub); CHKERRQ(ierr);
 
-        // add number of the subdomain to total number of cells
+        // add number of the sub-domain to total number of cells
         nTotal += nSub;
 
-        // append the subdomain dL to global dL
+        // append the sub-domain dL to global dL
         dL.insert(dL.end(), dLSub.begin(), dLSub.end());
     }
 
     PetscFunctionReturn(0);
-}
+} // parseSubDomains
 
 
 PetscErrorCode parseOneSubDomain(const YAML::Node &sub, const PetscReal bg,
@@ -205,10 +205,10 @@ PetscErrorCode parseOneSubDomain(const YAML::Node &sub, const PetscReal bg,
 {
     PetscFunctionBeginUser;
 
-    // get the number of the cells in this subdomain
+    // get the number of the cells in this sub-domain
     n = sub["cells"].as<PetscInt>();
 
-    // get the end of the subdomain
+    // get the end of the sub-domain
     ed = sub["end"].as<PetscReal>();
     
     // get the stretching ratio
@@ -221,7 +221,7 @@ PetscErrorCode parseOneSubDomain(const YAML::Node &sub, const PetscReal bg,
         misc::stretchGrid(bg, ed, n, r, dL);  // stretch grid
 
     PetscFunctionReturn(0);
-}
+} // parseOneSubDomain
 
 
 // get information about if we have periodic BCs from YAML node
@@ -259,7 +259,7 @@ PetscErrorCode parseBCs(const YAML::Node &node,
     }
     
     PetscFunctionReturn(0);
-}
+} // parseBCs
 
 
 // get initial conditions
@@ -284,7 +284,7 @@ PetscErrorCode parseICs(const YAML::Node &node, type::RealVec1D &icValues)
     for(unsigned int i=0; i<temp.size(); i++) icValues[i] = temp[i].as<PetscReal>();
     
     PetscFunctionReturn(0);
-}
+} // parseICs
 
 } // end of namespace parser
 } // end of namespace petibm
@@ -327,7 +327,7 @@ PetscErrorCode readYAMLs(YAML::Node &node)
     ierr = readSingleYAML(node, "bodies"); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // readYAMLs
 
 
 // private function. Read from a single YAML file that will overwrite a part 
@@ -357,7 +357,7 @@ PetscErrorCode readSingleYAML(YAML::Node &node, const std::string &s)
     }
 
     PetscFunctionReturn(0);
-}
+} // readSingleYAML
 
 
 PetscErrorCode checkAndCreateFolder(const std::string &dir)
@@ -389,4 +389,4 @@ PetscErrorCode checkAndCreateFolder(const std::string &dir)
     }
     
     PetscFunctionReturn(0);
-}
+} // checkAndCreateFolder

--- a/src/parser/yaml.cpp
+++ b/src/parser/yaml.cpp
@@ -1,7 +1,7 @@
 /**
  * \file yaml.cpp
  * \brief Implementations of YAML converters.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.

--- a/src/solution/solution.cpp
+++ b/src/solution/solution.cpp
@@ -1,7 +1,7 @@
 /**
  * \file solution.cpp
  * \brief Implementations of createSolution and members of SolutionBase.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -28,7 +28,7 @@ namespace solution
         ierr = VecDestroy(&UGlobal); CHKERRV(ierr);
         ierr = VecDestroy(&pGlobal); CHKERRV(ierr);
         comm = MPI_COMM_NULL;
-    }
+    } // ~SolutionBase
 
 
     PetscErrorCode SolutionBase::destroy()
@@ -46,7 +46,7 @@ namespace solution
         mesh.reset();
 
         PetscFunctionReturn(0);
-    }
+    } // destroy
 
 
     PetscErrorCode SolutionBase::printInfo() const
@@ -58,7 +58,7 @@ namespace solution
         ierr = io::print(info); CHKERRQ(ierr);
         
         PetscFunctionReturn(0);
-    }
+    } // printInfo
     
 
     PetscErrorCode createSolution(
@@ -69,6 +69,7 @@ namespace solution
         solution = std::make_shared<SolutionSimple>(mesh);
 
         PetscFunctionReturn(0);
-    }
-}
-}
+    } // createSolution
+
+} // end of namespace solution
+} // end of namespace petibm

--- a/src/solution/solutionsimple.cpp
+++ b/src/solution/solutionsimple.cpp
@@ -1,7 +1,7 @@
 /**
  * \file solutionsimple.cpp
  * \brief Implementations of the members of SolutionSimple.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -21,7 +21,7 @@ namespace solution
 
 using namespace type;
 
-// default deconstructor
+// default destructor
 SolutionSimple::~SolutionSimple() = default;
 
 
@@ -29,7 +29,7 @@ SolutionSimple::~SolutionSimple() = default;
 SolutionSimple::SolutionSimple(const Mesh &inMesh)
 {
     init(inMesh);
-}
+} // SolutionSimple
 
 
 // underlying initialization function
@@ -50,17 +50,17 @@ PetscErrorCode SolutionSimple::init(const Mesh &inMesh)
     // get a copy of dim
     dim = mesh->dim;
 
-    // create global composite vaector for q
+    // create global composite vector for q
     ierr = DMCreateGlobalVector(mesh->UPack, &UGlobal); CHKERRQ(ierr);
 
-    // create global composite vaector for pressure
+    // create global composite vector for pressure
     ierr = DMCreateGlobalVector(mesh->da[3], &pGlobal); CHKERRQ(ierr);
 
     // create info string
     ierr = createInfoString(); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // init
 
 
 // create a std::string for information
@@ -78,7 +78,7 @@ PetscErrorCode SolutionSimple::createInfoString()
     if (mpiRank == 0)
     {
         ss << std::string(80, '=') << std::endl;
-        ss << "Solution Vecters:" << std::endl;
+        ss << "Solution Vectors:" << std::endl;
         ss << std::string(80, '=') << std::endl;
 
         ss << "\tDimension: " << dim << std::endl;
@@ -96,7 +96,7 @@ PetscErrorCode SolutionSimple::createInfoString()
     info = ss.str();
 
     PetscFunctionReturn(0);
-}
+} // createInfoString
 
 
 // convert flux to velocity
@@ -117,7 +117,7 @@ PetscErrorCode SolutionSimple::convert2Velocity(const Mat &RInv)
     ierr = VecDestroy(&U); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // convert2Velocity
 
 
 // convert velocity to flux
@@ -138,7 +138,7 @@ PetscErrorCode SolutionSimple::convert2Flux(const Mat &R)
     ierr = VecDestroy(&F); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // convert2Flux
 
 
 // apply initial conditions
@@ -166,7 +166,7 @@ PetscErrorCode SolutionSimple::applyIC(const YAML::Node &node)
     ierr = VecSet(pGlobal, 0.0); CHKERRQ(ierr);
 
     PetscFunctionReturn(0);
-}
+} // applyIC
 
 
 PetscErrorCode SolutionSimple::write(const std::string &file) const
@@ -186,7 +186,7 @@ PetscErrorCode SolutionSimple::write(const std::string &file) const
     // set name for pressure
     names.back() = "p";
     
-    // get un-packed global Vecs from packed global Vec
+    // get unpacked global Vecs from packed global Vec
     ierr = DMCompositeGetAccessArray(mesh->UPack, UGlobal, dim, 
             nullptr, vecs.data()); CHKERRQ(ierr);
     
@@ -199,12 +199,12 @@ PetscErrorCode SolutionSimple::write(const std::string &file) const
     // nullify the reference to pressure Vec
     vecs.back() = PETSC_NULL;
     
-    // return un-packed global Vecs to packed global Vec
+    // return unpacked global Vecs to packed global Vec
     ierr = DMCompositeRestoreAccessArray(mesh->UPack, UGlobal, dim, 
             nullptr, vecs.data()); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // write
 
 
 PetscErrorCode SolutionSimple::read(const std::string &file)
@@ -224,7 +224,7 @@ PetscErrorCode SolutionSimple::read(const std::string &file)
     // set name for pressure
     names.back() = "p";
     
-    // get un-packed global Vecs from packed global Vec
+    // get unpacked global Vecs from packed global Vec
     ierr = DMCompositeGetAccessArray(mesh->UPack, UGlobal, dim, 
             nullptr, vecs.data()); CHKERRQ(ierr);
     
@@ -237,12 +237,12 @@ PetscErrorCode SolutionSimple::read(const std::string &file)
     // nullify the reference to pressure Vec
     vecs.back() = PETSC_NULL;
     
-    // return un-packed global Vecs to packed global Vec
+    // return unpacked global Vecs to packed global Vec
     ierr = DMCompositeRestoreAccessArray(mesh->UPack, UGlobal, dim, 
             nullptr, vecs.data()); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // read
 
 } // end of namespace solution
 } // end of namespace petibm

--- a/src/timeintegration/timeintegration.cpp
+++ b/src/timeintegration/timeintegration.cpp
@@ -1,7 +1,7 @@
 /**
  * \file timeintegration.cpp
  * \brief Implementations of TimeIntegration related classes.
- * \author Anush Krishnan (anus@bu.edu)
+ * \author Anush Krishnan (anush@bu.edu)
  * \author Olivier Mesnard (mesnardo@gwu.edu)
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \copyright MIT.
@@ -38,7 +38,7 @@ PetscErrorCode TimeIntegrationBase::printInfo() const
     ierr = PetscPrintf(PETSC_COMM_WORLD, "%s", info.c_str()); CHKERRQ(ierr);
     
     PetscFunctionReturn(0);
-}
+} // printInfo
 
 PetscErrorCode createTimeIntegration(const std::string &name,
         const YAML::Node &node, type::TimeIntegration &integration)
@@ -82,7 +82,7 @@ PetscErrorCode createTimeIntegration(const std::string &name,
 
 
     PetscFunctionReturn(0);
-}
+} // createTimeIntegration
 
 } // end of namespace timeintegration
 } // end of namespace petibm

--- a/tests/mesh/cartesianmesh2d_dirichlet.cpp
+++ b/tests/mesh/cartesianmesh2d_dirichlet.cpp
@@ -621,7 +621,7 @@ TEST_F(CartesianMeshTest2D_AllDirichlet, check_getGlobalIndex_ijk_internal)
         
         //ierr = ISLocalToGlobalMappingDestroy(&mapping); ASSERT_FALSE(ierr);
         // Seem there's a bug in ISLocalToGlobalMappingDestroy. It should just
-        // decrease the reference number by one. Instead, it now destroies the 
+        // decrease the reference number by one. Instead, it now destroys the 
         // underlying object completely....
         mapping = PETSC_NULL;
     }

--- a/tests/mesh/cartesianmesh2d_yperiodic.cpp
+++ b/tests/mesh/cartesianmesh2d_yperiodic.cpp
@@ -642,7 +642,7 @@ TEST_F(CartesainMeshTest2D_YPeriodic, check_getGlobalIndex_ijk_internal)
         
         //ierr = ISLocalToGlobalMappingDestroy(&mapping); ASSERT_FALSE(ierr);
         // Seem there's a bug in ISLocalToGlobalMappingDestroy. It should just
-        // decrease the reference number by one. Instead, it now destroies the 
+        // decrease the reference number by one. Instead, it now destroys the 
         // underlying object completely....
         mapping = PETSC_NULL;
     }


### PR DESCRIPTION
Correct typos in docstrings and add functions' name at end of functions and "end of namespace X" at end of namespace.